### PR TITLE
「skill_climbing」の名残を排除した

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@
 ## 4. 環境構築手順
 1. リポジトリをローカルにcloneする
   - 以下コマンドを実行する。
-    - `git clone git@github.com:mnmuu8/skill-climbing-frontend.git`
+    - `git clone git@github.com:mnmuu8/frontend_stack.git`
 2. Dockerイメージの作成
   - 以下コマンドを実行する。
     - `make build`
 3. Dockerネットワークの作成
   - 以下コマンドを実行する。
-    - `docker network create skill-climbing-shared-network`
+    - `docker network create stack_shared_network`
 4. Dockerコンテナを立ち上げる
   - 以下コマンドを実行する。
     - `make up`


### PR DESCRIPTION
## Epic


## PBI


## OpenAPI

## PRマージ後に実行するコマンド
```
$ make down
$ docker network create stack_shared_network
$ make build
```

## 対象画面キャプチャ

## やったこと
- リポジトリ名変更に伴って「skill_climbing」という名前をコード上から排除した。
## このPRでやらないこと

## 動作確認
- [ ] 確認済み

## その他
- 