### PR TITLE
ユーザー作成APIのリクエストボディにpasswordも追加した

### DIFF
--- a/generated-api/models/UserCreateRequestBody.ts
+++ b/generated-api/models/UserCreateRequestBody.ts
@@ -51,6 +51,18 @@ export interface UserCreateRequestBody {
      */
     role: UsersUserRole;
     /**
+     * ユーザーのパスワード
+     * @type {string}
+     * @memberof UserCreateRequestBody
+     */
+    password: string;
+    /**
+     * ユーザーのパスワード
+     * @type {string}
+     * @memberof UserCreateRequestBody
+     */
+    passwordConfirmation: string;
+    /**
      * チームID
      * @type {number}
      * @memberof UserCreateRequestBody
@@ -67,6 +79,8 @@ export function instanceOfUserCreateRequestBody(value: object): boolean {
     isInstance = isInstance && "email" in value;
     isInstance = isInstance && "profileContent" in value;
     isInstance = isInstance && "role" in value;
+    isInstance = isInstance && "password" in value;
+    isInstance = isInstance && "passwordConfirmation" in value;
     isInstance = isInstance && "teamId" in value;
 
     return isInstance;
@@ -86,6 +100,8 @@ export function UserCreateRequestBodyFromJSONTyped(json: any, ignoreDiscriminato
         'email': json['email'],
         'profileContent': json['profile_content'],
         'role': UsersUserRoleFromJSON(json['role']),
+        'password': json['password'],
+        'passwordConfirmation': json['password_confirmation'],
         'teamId': json['team_id'],
     };
 }
@@ -103,6 +119,8 @@ export function UserCreateRequestBodyToJSON(value?: UserCreateRequestBody | null
         'email': value.email,
         'profile_content': value.profileContent,
         'role': UsersUserRoleToJSON(value.role),
+        'password': value.password,
+        'password_confirmation': value.passwordConfirmation,
         'team_id': value.teamId,
     };
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -1316,6 +1316,8 @@ components:
         - email
         - profile_content
         - role
+        - password
+        - password_confirmation
         - team_id
       properties:
         name:
@@ -1333,6 +1335,14 @@ components:
         role:
           allOf:
             - $ref: '#/components/schemas/Users_User_Role'
+          nullable: false
+        password:
+          allOf:
+            - $ref: '#/components/schemas/Users_User_Password'
+          nullable: false
+        password_confirmation:
+          allOf:
+            - $ref: '#/components/schemas/Users_User_Password'
           nullable: false
         team_id:
           allOf:


### PR DESCRIPTION
#62 の修正

## Epic
[ユーザーを新規登録できる](https://app.asana.com/0/1204548322306328/1205544384881385/f)

## PBI
[チームメンバー追加APIを作成する](https://app.asana.com/0/1204548322306328/1205826687920690/f)

## 対象画面キャプチャ


## 実行するコマンド


## やったこと
- ユーザー作成APIのリクエストボディにpasswordも追加した

## このPRでやらないこと
- 

## 動作確認
- [x] 確認済み

## その他
- 