### PR TITLE
プロフィール画像登録用APIのレスポンスに409の場合を定義した

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -355,6 +355,8 @@ paths:
           description: 認証エラー
         '404':
           description: ユーザーが存在しない
+        '409':
+          description: プロフィール画像の登録に失敗
         '422':
           description: バリデーションエラー
 


### PR DESCRIPTION
https://github.com/mnmuu8/frontend_stack/pull/66 の修正版

## Epic


## PBI


## 対象画面キャプチャ


## 実行するコマンド


## やったこと
- 

## このPRでやらないこと
- 

## 動作確認
- [x] 確認済み

## その他
- 