### PR TITLE
スキル毎にランクを確認できるようにした

### DIFF
--- a/components/molecules/ProfileCard.tsx
+++ b/components/molecules/ProfileCard.tsx
@@ -1,8 +1,5 @@
 import React, { FC, useContext } from 'react';
-import Link from 'next/link';
 import ImageWrapper from '../atoms/ImageWrapper';
-import TwitterIcon from '@mui/icons-material/Twitter';
-import InstagramIcon from '@mui/icons-material/Instagram';
 import { FormContext } from '@/context/FormContext';
 import { SessionContext } from '@/context/SessionContext';
 
@@ -32,14 +29,6 @@ const ProfileCard: FC = () => {
           className='rounded-full m-auto'
         />
         <div className='text-center mt-2 font-bold'>{sessionUser.name}</div>
-        <div className='flex justify-center mt-2'>
-          <Link href=''>
-            <TwitterIcon className='text-gray-400 mx-1' />
-          </Link>
-          <Link href=''>
-            <InstagramIcon className='text-gray-400 mx-1' />
-          </Link>
-        </div>
         <div className='text-sm mt-4'>
           フロントエンドエンジニアです。 主に日々の学習で学んだことをアウトプットしています(React多め)。
           初学者故、至らぬ点等ございますが温かい目で見守っていただけると幸いです。

--- a/components/templates/DashboardWrapper.tsx
+++ b/components/templates/DashboardWrapper.tsx
@@ -97,6 +97,7 @@ const DashboardWrapper: FC = () => {
             bdwidth={1}
             text={currentMonth + '月の学習時間'}
             type={'bar'}
+            pattern={1}
           />
         </div>
       </div>
@@ -114,6 +115,7 @@ const DashboardWrapper: FC = () => {
                 bdwidth={1}
                 text={'積み上げスキル'}
                 type={'pie'}
+                pattern={2}
               />
             </div>
           </div>

--- a/components/templates/MyPageWrapper.tsx
+++ b/components/templates/MyPageWrapper.tsx
@@ -4,14 +4,17 @@ import StackCard from '../molecules/StackCard';
 import ProfileCard from '../molecules/ProfileCard';
 import axios from 'axios';
 import { getSession } from '@/utiliry/session';
-import { ApiOptions } from '@/types/api';
 import { StackProps } from '@/types/stack';
 import { getApiHeadersWithUserId } from '@/utiliry/api';
+import Chart from '../uikit/Chart';
 
 const MyPageWrapper: FC = () => {
   const [activeTab, setActiveTab] = useState('all');
   const [innerTab, setInnerTab] = useState('allStack');
   const [stacks, setStacks] = useState<StackProps[]>([]);
+
+  const [skills, setSkills] = useState<string[]>([]);
+  const [minutes, setMinutes] = useState<number[]>([]);
 
   const handleTabClick = (tab: string) => {
     setActiveTab(tab);
@@ -42,10 +45,49 @@ const MyPageWrapper: FC = () => {
       });
   }, []);
 
+  useEffect(() => {
+    const skillAccumulation: {[skill: string]: number} = {};
+
+    stacks.forEach(stack => {
+      const { skill, minutes } = stack;
+      if (skillAccumulation[skill.name]) {
+        skillAccumulation[skill.name] += minutes;
+      } else {
+        skillAccumulation[skill.name] = minutes;
+      }
+    });
+
+    setSkills(Object.keys(skillAccumulation));
+    setMinutes(Object.values(skillAccumulation));
+  }, [stacks])
+
   return (
     <div className='flex justify-between w-[80%] m-auto'>
       <ProfileCard />
       <div className='w-[calc(100%-340px)]'>
+        <div className='bg-gray-50 mb-8'>
+          <div className='p-6'>
+            <Chart
+              labels={skills}
+              label={'時間'}
+              data={minutes}
+              bdColor={['rgb(39, 119, 169)']}
+              bgColor={['rgb(240, 248, 250)']}
+              bdwidth={1}
+              text={'スキル毎のランク'}
+              type={'bar'}
+              pattern={3}
+            />
+          </div>
+          <div className='py-6 flex items-center justify-center bg-gray-100'>
+            <div className='flex items-center mr-4'><span className='w-3 h-3 block bg-opal mr-1'></span><span className='text-sm'>Opal</span></div>
+            <div className='flex items-center mr-4'><span className='w-3 h-3 block bg-bronze mr-1'></span><span className='text-sm'>Bronze</span></div>
+            <div className='flex items-center mr-4'><span className='w-3 h-3 block bg-silver mr-1'></span><span className='text-sm'>Silver</span></div>
+            <div className='flex items-center mr-4'><span className='w-3 h-3 block bg-gold mr-1'></span><span className='text-sm'>Gold</span></div>
+            <div className='flex items-center mr-4'><span className='w-3 h-3 block bg-platinum mr-1'></span><span className='text-sm'>Platinum</span></div>
+            <div className='flex items-center mr-4'><span className='w-3 h-3 block bg-diamond mr-1'></span><span className='text-sm'>Diamond</span></div>
+          </div>
+        </div>
         <div className='bg-gray-800 text-white rounded-md py-8 px-10 mb-8 shadow-md'>
           <div className='mb-6'>$ analyze @Yu-8chan</div>
           <div className='flex justify-between'>

--- a/components/templates/MyPageWrapper.tsx
+++ b/components/templates/MyPageWrapper.tsx
@@ -88,26 +88,6 @@ const MyPageWrapper: FC = () => {
             <div className='flex items-center mr-4'><span className='w-3 h-3 block bg-diamond mr-1'></span><span className='text-sm'>Diamond</span></div>
           </div>
         </div>
-        <div className='bg-gray-800 text-white rounded-md py-8 px-10 mb-8 shadow-md'>
-          <div className='mb-6'>$ analyze @Yu-8chan</div>
-          <div className='flex justify-between'>
-            {skillData.map((data) => (
-              <div key={data.label} className='w-[48%]'>
-                <div className='text-green-400 mb-2'>{data.label}:</div>
-                <div className='px-6'>
-                  {data.data.map((d) => (
-                    <div key={d.skill} className='flex justify-between'>
-                      <div>{d.skill}:</div>
-                      <div className='text-orange-300'>
-                        {d.value} {data.label === '積み上げスキル' ? '%' : 'h'}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
         <div className='flex text-sm mb-8'>
           {Object.keys(tabInfo).map((tab) => (
             <div

--- a/components/uikit/Chart.tsx
+++ b/components/uikit/Chart.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState, useEffect } from 'react';
 import { ChartProps, ChartData, ChartOption } from '@/types/utils';
 import { Bar, Pie } from 'react-chartjs-2';
+import Annotation from 'chartjs-plugin-annotation';
 
 import {
   Chart as ChartJS,
@@ -15,15 +16,24 @@ import {
   Legend,
 } from 'chart.js';
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Title, Tooltip, Legend);
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Title, Tooltip, Legend, Annotation);
 
-const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth, text, type }) => {
+const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth, text, type, pattern }) => {
   const [chartData, setChartData] = useState<ChartData | null>(null);
   const [chartOption, setChartOption] = useState<ChartOption | null>(null);
   const [chartType, setChartType] = useState<'bar' | 'pie' | null>(null);
 
-  useEffect(() => {
-    const formattedChartData: ChartData = {
+  const RankingIndex = (minutes: number) => {
+    if (minutes < 100) return 'Opal';
+    if (minutes >= 100 && minutes < 200) return 'Bronze';
+    if (minutes >= 200 && minutes < 300) return 'Silver';
+    if (minutes >= 300 && minutes < 400) return 'Gold';
+    if (minutes >= 400 && minutes < 500) return 'Platinum';
+    if (minutes >= 500) return 'Diamond';
+  }
+
+  const getChartData = () => {
+    const chartData: ChartData = {
       labels: labels,
       datasets: [
         {
@@ -35,15 +45,57 @@ const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth,
         },
       ],
     };
-    const formattedChartOptions: ChartOption = {
-      responsive: true,
-      plugins: {
-        title: {
-          display: true,
-          text: text,
+
+    return chartData;
+  }
+
+  const getChartOptions = (pattern: number) => {
+    if (pattern === 3) {
+      const chartOptions: ChartOption = {
+        responsive: true,
+        plugins: {
+          title: {
+            display: true,
+            text: text,
+          },
+          tooltip: {
+            callbacks: {
+              label: function(context) {
+                const minutes = context.parsed.y;
+                const rank = RankingIndex(minutes);
+                return `時間: ${minutes}  ランク: ${rank}`;
+              }
+            }
+          },
+          annotation: {
+            annotations: {
+              diamondLine: { type: 'line', yMin: 500, yMax: 500, borderColor: 'rgba(255, 255, 255, 0.5)', borderWidth: 2 },
+              platinumLine: { type: 'line', yMin: 400, yMax: 400, borderColor: 'rgba(229, 228, 226, 0.5)', borderWidth: 2 },
+              goldLine: { type: 'line', yMin: 300, yMax: 300, borderColor: 'rgba(255, 215, 0, 0.5)', borderWidth: 2 },
+              silverLine: { type: 'line', yMin: 200, yMax: 200, borderColor: 'rgba(192, 192, 192, 0.5)', borderWidth: 2 },
+              bronzeLine: { type: 'line', yMin: 100, yMax: 100, borderColor: 'rgba(205, 127, 50, 0.5)', borderWidth: 2 },
+            }
+          }
         },
-      },
-    };
+      };
+      return chartOptions;
+    } else {
+      const chartOptions: ChartOption = {
+        responsive: true,
+        plugins: {
+          title: {
+            display: true,
+            text: text,
+          },
+        },
+      };
+      return chartOptions;
+    }
+  }
+
+  useEffect(() => {
+    const formattedChartData = getChartData()
+    const formattedChartOptions = getChartOptions(pattern)
 
     setChartType(type);
     setChartData(formattedChartData);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
         "axios": "^1.5.0",
+        "chartjs-plugin-annotation": "^3.0.1",
         "cookie": "^0.6.0",
         "dayjs": "^1.11.9",
         "draft-js": "^0.11.7",
@@ -972,8 +973,7 @@
     "node_modules/@kurkle/color": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
-      "dev": true
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -2390,12 +2390,19 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.0.tgz",
       "integrity": "sha512-vQEj6d+z0dcsKLlQvbKIMYFHd3t8W/7L2vfJIbYcfyPcRx92CsHqECpueN8qVGNlKyDcr5wBrYAYKnfu/9Q1hQ==",
-      "dev": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
       "engines": {
         "pnpm": ">=7"
+      }
+    },
+    "node_modules/chartjs-plugin-annotation": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.0.1.tgz",
+      "integrity": "sha512-hlIrXXKqSDgb+ZjVYHefmlZUXK8KbkCPiynSVrTb/HjTMkT62cOInaT1NTQCKtxKKOm9oHp958DY3RTAFKtkHg==",
+      "peerDependencies": {
+        "chart.js": ">=4.0.0"
       }
     },
     "node_modules/chokidar": {
@@ -7564,8 +7571,7 @@
     "@kurkle/color": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
-      "dev": true
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "@lukeed/csprng": {
       "version": "1.1.0",
@@ -8412,10 +8418,15 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.0.tgz",
       "integrity": "sha512-vQEj6d+z0dcsKLlQvbKIMYFHd3t8W/7L2vfJIbYcfyPcRx92CsHqECpueN8qVGNlKyDcr5wBrYAYKnfu/9Q1hQ==",
-      "dev": true,
       "requires": {
         "@kurkle/color": "^0.3.0"
       }
+    },
+    "chartjs-plugin-annotation": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.0.1.tgz",
+      "integrity": "sha512-hlIrXXKqSDgb+ZjVYHefmlZUXK8KbkCPiynSVrTb/HjTMkT62cOInaT1NTQCKtxKKOm9oHp958DY3RTAFKtkHg==",
+      "requires": {}
     },
     "chokidar": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",
     "axios": "^1.5.0",
+    "chartjs-plugin-annotation": "^3.0.1",
     "cookie": "^0.6.0",
     "dayjs": "^1.11.9",
     "draft-js": "^0.11.7",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,16 @@ module.exports = {
     "./utiliry/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        diamond: '#ffffff',
+        platinum: '#e5e4e2',
+        gold: '#ffd700',
+        silver: '#c0c0c0',
+        bronze: '#cd7f32',
+        opal: '#a9ffff',
+      },
+    },
   },
   plugins: [],
 }

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { StaticImageData } from 'next/image';
+import { TooltipItem } from 'chart.js';
 
 export type ChildrenProps = {
   children: ReactNode;
@@ -26,6 +27,14 @@ export type ChartData = {
   datasets: any[];
 };
 
+export type AnnotationLine = {
+  type: 'line';
+  yMin: number;
+  yMax: number;
+  borderColor: string;
+  borderWidth: number;
+}
+
 export type ChartOption = {
   responsive: boolean;
   plugins: {
@@ -33,6 +42,20 @@ export type ChartOption = {
       display: boolean;
       text: string;
     };
+    tooltip?: {
+      callbacks: {
+        label: (context: TooltipItem<'bar'>) => string;
+      };
+    };
+    annotation?: {
+      annotations: {
+        diamondLine: AnnotationLine;
+        platinumLine: AnnotationLine;
+        goldLine: AnnotationLine;
+        silverLine: AnnotationLine;
+        bronzeLine: AnnotationLine;
+      }
+    }
   };
 };
 
@@ -45,6 +68,7 @@ export type ChartProps = {
   bdwidth: number;
   text: string;
   type: 'bar' | 'pie';
+  pattern: number;
 };
 
 export type FormSubmitButtonProps = {


### PR DESCRIPTION
## Epic
[スキル毎の積み上げに応じてランクが付与される](https://app.asana.com/0/1204548322306328/1205735308576659/f)

## PBI
[マイページでスキル毎のランクを確認することができる](https://app.asana.com/0/1204548322306328/1205826687402975/f)

## 対象画面キャプチャ
<img width="1177" alt="スクリーンショット 2023-12-02 14 58 23" src="https://github.com/mnmuu8/frontend_stack/assets/121008362/7cc3d964-0f56-41d7-afb5-673e8b3394b2">

## 実行するコマンド
なし

## やったこと
- スキル毎にランクを表示
- マイページの不要なパーツ削除

## このPRでやらないこと
- なし

## 動作確認
- [x] 確認済み

## その他
一先ず実装したけど、ランクの種別とか時間とか適当に割り当てたから要望あれば修正するで〜