### PR TITLE
ユーザーが所属するチーム全体の積み上げ一覧を表示できるようにした

### DIFF
--- a/components/molecules/StackCard.tsx
+++ b/components/molecules/StackCard.tsx
@@ -1,10 +1,7 @@
 import React, { FC, useContext, useEffect, useState } from 'react';
 import UserProfile from './UserProfile';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
-import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
-import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import { formatDate } from '../uikit/dateUtils';
-import { ApiOptions } from '@/types/api';
 import { IntrospectionProps } from '@/types/introspection';
 import { StackCardProps } from '@/types/stack';
 import { getSession } from '@/utiliry/session';
@@ -79,38 +76,35 @@ const StackCard: FC<StackCardProps> = ({ stack }) => {
             created_at={formattedCreateDate}
           />
         </div>
-        <div className='pt-4 pb-2 text-lg font-bold'>{stack.title}</div>
-        <div className='flex items-center'>
-          <div>
-            <LocalOfferIcon className='text-gray-400 text-[16px] mr-2 relative top-[-1px]' />
-          </div>
-          <div key={stack.skill.id} className='bg-gray-200 rounded-md text-[12px] mr-2 py-1 px-2'>
-            {stack.skill.name}
-          </div>
+        <div className='py-4'>
+          <div className='text-lg font-bold mb-2'>{stack.title}</div>
+          <div className='text-md'>{stack.description}</div>
         </div>
-        <div className='flex text-sm mt-2'>
-          <div className='flex items-center mr-4'>
-            <FavoriteBorderIcon className='text-gray-400 text-[20px] mr-1' /> 0
-          </div>
+        <div className='flex justify-between'>
           <div className='flex items-center'>
-            <BookmarkBorderIcon className='text-gray-400 text-[20px] mr-1' /> 0
+            <div>
+              <LocalOfferIcon className='text-gray-400 text-[16px] mr-2 relative top-[-1px]' />
+            </div>
+            <div key={stack.skill.id} className='bg-gray-200 rounded-md text-[12px] mr-2 py-1 px-2'>
+              {stack.skill.name}
+            </div>
           </div>
+          {introspectionValue ? (
+            <div
+              className='bg-blue-500 text-blue-100 hover:bg-blue-600 text-sm font-bold rounded-full px-4 py-2 mt-2 w-[90px] text-center cursor-pointer'
+              onClick={handleEditFormOpen}
+            >
+              反省詳細
+            </div>
+          ) : (
+            <div
+              className='bg-blue-100 text-blue-500 hover:bg-blue-200 text-sm font-bold rounded-full px-4 py-2 mt-2 w-[90px] text-center cursor-pointer'
+              onClick={handleNewFormOpen}
+            >
+              反省追加
+            </div>
+          )}
         </div>
-        {introspectionValue ? (
-          <div
-            className='bg-blue-500 text-blue-100 hover:bg-blue-600 text-sm font-bold rounded-full px-4 py-2 mt-2 ml-auto w-[90px] text-center cursor-pointer'
-            onClick={handleEditFormOpen}
-          >
-            反省詳細
-          </div>
-        ) : (
-          <div
-            className='bg-blue-100 text-blue-500 hover:bg-blue-200 text-sm font-bold rounded-full px-4 py-2 mt-2 ml-auto w-[90px] text-center cursor-pointer'
-            onClick={handleNewFormOpen}
-          >
-            反省追加
-          </div>
-        )}
       </div>
     </div>
   );

--- a/components/molecules/StackList.tsx
+++ b/components/molecules/StackList.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import StackCard from '@/components/molecules/StackCard';
 import { StackProps } from '@/types/stack';
 
-const StackList: FC<{stacks: StackProps[]}> = ({ stacks }) => {
+const StackList: FC<{ stacks: StackProps[] }> = ({ stacks }) => {
   return (
     <div className='w-full max-w-[980px] m-auto pb-10'>
       {stacks.map((stack) => (

--- a/components/molecules/StackList.tsx
+++ b/components/molecules/StackList.tsx
@@ -1,71 +1,13 @@
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC } from 'react';
 import StackCard from '@/components/molecules/StackCard';
-import SelectBox from './SelectBox';
-import { SelectChangeEvent } from '@mui/material/Select';
-import { getSession } from '@/utiliry/session';
-import { ApiOptions } from '@/types/api';
 import { StackProps } from '@/types/stack';
-import axios from 'axios';
-import { getApiHeadersWithUserId } from '@/utiliry/api';
 
-const StackList: FC = () => {
-  const [selectedOption, setSelectedOption] = useState<string>('all');
-  const [filteredStackLists, setFilteredStackLists] = useState<StackProps[]>([]);
-  const [stacks, setStacks] = useState<StackProps[]>([]);
-
-  const handleOptionChange = (event: SelectChangeEvent<string>) => {
-    setSelectedOption(event.target.value);
-  };
-
-  useEffect(() => {
-    const sessionData = getSession();
-    if (!sessionData) return;
-
-    const options = getApiHeadersWithUserId(sessionData);
-    axios
-      .get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options)
-      .then((response) => {
-        const { data } = response;
-        setStacks(data.stacks);
-      })
-      .catch((error) => {
-        if (error.response) {
-          const { data } = error.response;
-          throw new Error(`${JSON.stringify(data)}`);
-        } else {
-          throw new Error(`${JSON.stringify(error)}`);
-        }
-      });
-  }, []);
-
-  // TODO: 一旦仮で作成。後ほど項目増やしてフィルターかけて表示する
-  useEffect(() => {
-    const filterStackLists = () => {
-      if (selectedOption === 'following') {
-        setFilteredStackLists(stacks.filter((list) => list.id === 1));
-      } else if (selectedOption === 'notFollowing') {
-        setFilteredStackLists(stacks.filter((list) => list.id === 2));
-      } else {
-        setFilteredStackLists(stacks);
-      }
-    };
-
-    filterStackLists();
-  }, [stacks, selectedOption]);
-
+const StackList: FC<{stacks: StackProps[]}> = ({ stacks }) => {
   return (
     <div className='w-full max-w-[980px] m-auto pb-10'>
-      <div className='mb-4'>
-        <SelectBox selectedOption={selectedOption} handleOptionChange={handleOptionChange} />
-      </div>
-      <div>
-        {filteredStackLists.map((stack) => (
-          <StackCard key={stack.id} stack={stack} />
-        ))}
-      </div>
-      <div className='w-[280px] m-auto mt-10 rounded-md border-2 cursor-pointer border-gray-200 text-center text-sm py-3 duration-300 hover:bg-gray-50 hover:duration-300'>
-        もっとみる
-      </div>
+      {stacks.map((stack) => (
+        <StackCard key={stack.id} stack={stack} />
+      ))}
     </div>
   );
 };

--- a/components/templates/MyPageWrapper.tsx
+++ b/components/templates/MyPageWrapper.tsx
@@ -33,7 +33,7 @@ const MyPageWrapper: FC = () => {
       .get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options)
       .then((response) => {
         const { data } = response;
-        setStacks(data.stacks);
+        setStacks(data.stacks.reverse());
       })
       .catch((error) => {
         if (error.response) {

--- a/components/templates/MyPageWrapper.tsx
+++ b/components/templates/MyPageWrapper.tsx
@@ -33,7 +33,7 @@ const MyPageWrapper: FC = () => {
       .get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options)
       .then((response) => {
         const { data } = response;
-        setStacks(data.stacks.reverse());
+        setStacks(data.stacks);
       })
       .catch((error) => {
         if (error.response) {

--- a/components/uikit/Chart.tsx
+++ b/components/uikit/Chart.tsx
@@ -117,7 +117,7 @@ const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth,
                 yMin: 30000,
                 yMax: 30000,
                 borderColor: 'rgba(255, 215, 0, 0.5)',
-                borderWidth: 2
+                borderWidth: 2,
               },
               silverLine: {
                 type: 'line',
@@ -131,8 +131,8 @@ const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth,
         },
         scales: {
           y: {
-            suggestedMax: scaledMax
-          }
+            suggestedMax: scaledMax,
+          },
         },
       };
       return chartOptions;

--- a/generated-api/apis/StackApi.ts
+++ b/generated-api/apis/StackApi.ts
@@ -43,6 +43,7 @@ export interface ApiV1StacksCreateRequest {
 
 export interface ApiV1StacksIndexRequest {
     userId?: number;
+    teamId?: number;
 }
 
 export interface ApiV1StacksIntrospectionsCreateRequest {
@@ -105,6 +106,10 @@ export class StackApi extends runtime.BaseAPI {
 
         if (requestParameters.userId !== undefined) {
             queryParameters['user_id'] = requestParameters.userId;
+        }
+
+        if (requestParameters.teamId !== undefined) {
+            queryParameters['team_id'] = requestParameters.teamId;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/openapi.yml
+++ b/openapi.yml
@@ -49,6 +49,11 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/Users_User_Id'
+        - name: team_id
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/Teams_Team_Id'
       responses:
         '200':
           description: 成功

--- a/pages/timeline/index.tsx
+++ b/pages/timeline/index.tsx
@@ -1,16 +1,53 @@
-import React from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { NextPage } from 'next'
 import Layout from '@/components/organisms/Layout'
 import StackList from '@/components/molecules/StackList'
 import FormModal from '@/components/molecules/FormModal'
+import { StackProps } from '@/types/stack'
+import { getSession } from '@/utiliry/session'
+import { ApiOptions } from '@/types/api'
+import { SessionContext } from '@/context/SessionContext'
+import axios from 'axios'
 
-const index: NextPage = () => {
+const Index: NextPage = () => {
+  const [stacks, setStacks] = useState<StackProps[]>([]);
+  
+  const sessionContext = useContext(SessionContext);
+  const { sessionUser } = sessionContext
+
+  useEffect(() => {
+    const sessionData = getSession();
+    if (!sessionData) return;
+
+    const fetchStacks = async () => {
+      const options: ApiOptions = {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${sessionData.token}`
+        },
+        params: { team_id: sessionUser?.team.id }
+      };
+      const url = `${process.env.API_ROOT_URL}/api/v1/stacks`
+
+      try {
+        const response = await axios.get(url, options);
+        const reversedStacks = response.data.stacks.reverse();
+        return reversedStacks;
+      } catch (error) {
+        throw new Error(`${JSON.stringify(error)}`);
+      }
+    };
+
+    fetchStacks().then((res) => { setStacks(res); });
+  }, [stacks]);
+
   return (
     <Layout>
-      <StackList />
+      <div className='text-center text-xl font-bold mb-6'>「チーム{sessionUser?.team.id}」の積み上げ一覧</div>
+      <StackList stacks={stacks} />
       <FormModal />
     </Layout>
   )
 }
 
-export default index
+export default Index

--- a/pages/timeline/index.tsx
+++ b/pages/timeline/index.tsx
@@ -31,8 +31,7 @@ const Index: NextPage = () => {
 
       try {
         const response = await axios.get(url, options);
-        const reversedStacks = response.data.stacks.reverse();
-        return reversedStacks;
+        return response.data.stacks;
       } catch (error) {
         throw new Error(`${JSON.stringify(error)}`);
       }

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -61,8 +61,8 @@ export type ChartOption = {
   scales?: {
     y: {
       suggestedMax: number;
-    }
-  }
+    };
+  };
 };
 
 export type ChartProps = {


### PR DESCRIPTION
## Epic
[タイムラインでチーム全体の積み上げを見れるようにする](https://app.asana.com/0/1204548322306328/1205627542038988/f)

## PBI
[ログインユーザーが所属しているチーム全体の積み上げがタイムラインで確認できる](https://app.asana.com/0/1204548322306328/1205826687402983/f)

## 対象画
![スクリーンショット 2023-12-05 16 56 37](https://github.com/mnmuu8/frontend_stack/assets/121008362/d5a3ed2f-95e2-483f-b5cf-dd11bb469b1f)
面キャプチャ

## 実行するコマンド
- なし

## やったこと
- ユーザーが所属するチーム全体の積み上げ一覧を表示できるようにした
- openapi.yml修正

## このPRでやらないこと
- なし

## 動作確認
- [x] 確認済み

## その他
- なし