### PR TITLE
現在選択しているページが分かりやすいようにサイドバーに背景色を追加した

### DIFF
--- a/components/organisms/Sidebar.tsx
+++ b/components/organisms/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useContext } from 'react';
+import { useRouter } from 'next/router';
 import { sidebarMenus } from '@/types/utils';
 import { AppContext } from '@/context/AppContext';
 import Link from 'next/link';
@@ -31,6 +32,8 @@ const Sidebar: FC = () => {
     { id: 'message', label: 'メッセージ', value: '/message', icon: <MessageIcon /> },
     { id: 'outputs', label: 'アウトプット', value: '/outputs', icon: <OutputIcon /> },
   ];
+  const router = useRouter();
+  const isActive = (path: string) => router.pathname === path;
 
   return (
     <aside>
@@ -53,8 +56,8 @@ const Sidebar: FC = () => {
         <div className='bg-gray-50 flex-grow'>
           <List>
             {sidebarMenus.map((menu) => (
-              <ListItem key={menu.id} disablePadding>
-                <ListItemButton>
+              <ListItem key={menu.id} disablePadding sx={isActive(menu.value) ? { backgroundColor: '#D1D5DB' } : {}}>
+                <ListItemButton >
                   <ListItemIcon>{menu.icon}</ListItemIcon>
                   <Link href={menu.value}>{menu.label}</Link>
                 </ListItemButton>


### PR DESCRIPTION
## Epic


## PBI
[サイドバーのどれを現在選択しているのか分かりやすくする](https://app.asana.com/0/1204548322306328/1205627542038977/f)

## 対象画面キャプチャ
https://github.com/mnmuu8/frontend_stack/assets/62938854/1bda2d28-4b11-44a3-a2c4-27caa1d64863

## 実行するコマンド


## やったこと
- 現在選択しているページが分かりやすいようにサイドバーに背景色を追加した

## このPRでやらないこと
- 

## 動作確認
- [ ] 確認済み

## その他
- 