### PR TITLE
クッキーの処理改修

### DIFF
--- a/components/organisms/Layout.tsx
+++ b/components/organisms/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useState } from 'react';
+import React, { FC, useContext, useEffect } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import { LayoutProps } from '@/types/utils';
@@ -10,6 +10,8 @@ import { SessionContext } from '@/context/SessionContext';
 import { getApiHeaders } from '@/utiliry/api';
 
 const Layout: FC<LayoutProps> = ({ children }) => {
+  const router = useRouter();
+
   const appContext = useContext(AppContext);
   const { drawerArea } = appContext;
 
@@ -18,31 +20,6 @@ const Layout: FC<LayoutProps> = ({ children }) => {
 
   const mainStyle: React.CSSProperties = {
     width: drawerArea ? 'calc(100% - 240px)' : '100%',
-  };
-
-  const router = useRouter();
-
-  const checkActivity = () => {
-    const sessionData = getSession();
-    if (sessionData === false) return;
-
-    const currentTime = new Date().getTime();
-    if (currentTime - sessionData.lastActivity >= sessionData.exp) {
-      localStorage.removeItem('session');
-    }
-  };
-
-  const updateActivity = () => {
-    const sessionData = getSession();
-    if (sessionData === false) return;
-
-    const lastActivity = new Date().getTime();
-    sessionData.lastActivity = lastActivity;
-    localStorage.setItem('session', JSON.stringify(sessionData));
-  };
-
-  const handleRouteChange = () => {
-    updateActivity();
   };
 
   useEffect((): void => {
@@ -54,40 +31,37 @@ const Layout: FC<LayoutProps> = ({ children }) => {
 
     const options = getApiHeaders();
 
-    axios
-      .get(`${process.env.API_ROOT_URL}/api/v1/users/${sessionData.userId}`, options)
+    axios.get(`${process.env.API_ROOT_URL}/api/v1/users/${sessionData.userId}`, options)
       .then((response) => {
         const { data } = response;
         setSessionUser(data);
       })
       .catch((error) => {
-        if (error.response) {
-          const { data } = error.response;
-          throw new Error(`${JSON.stringify(data)}`);
-        } else {
-          throw new Error(`${JSON.stringify(error)}`);
-        }
+        throw new Error(`${JSON.stringify(error)}`);
       });
   }, []);
 
   useEffect(() => {
-    const sessionData = getSession();
-    if (!sessionData) return;
-
-    updateActivity();
-
-    router.events.on('routeChangeComplete', handleRouteChange);
-    const intervalId = setInterval(checkActivity, 60 * 3000);
-
-    return () => {
-      router.events.off('routeChangeComplete', handleRouteChange);
-      clearInterval(intervalId);
-    };
-  }, [router]);
-
-  useEffect(() => {
     sessionUser && sessionUser.role === 'admin' ? setIsAdmin(true) : setIsAdmin(false);
   }, [sessionUser, isAdmin]);
+
+  useEffect(() => {
+    const CheckSession = async () => {
+      try {
+        const response = await axios.get('/api/check-session');
+        if (!response.data.session) {
+          axios.post('/api/logout');
+          localStorage.removeItem('session');
+          setSessionUser(undefined);
+
+          router.push('/login');
+        }
+      } catch (error) {
+        router.push('/login');
+      }
+    };
+    CheckSession()
+  }, [router]);
 
   return (
     <div className='h-screen'>

--- a/components/uikit/HeaderMenu.tsx
+++ b/components/uikit/HeaderMenu.tsx
@@ -7,6 +7,7 @@ import Settings from '@mui/icons-material/Settings';
 import Logout from '@mui/icons-material/Logout';
 import { AppContext } from '@/context/AppContext';
 import { SessionContext } from '@/context/SessionContext';
+import axios from 'axios';
 
 const HeaderMenu: FC = () => {
   const appContext = useContext(AppContext);
@@ -18,10 +19,16 @@ const HeaderMenu: FC = () => {
   const open = Boolean(anchorEl);
   const router = useRouter();
 
-  const logoutUser = () => {
-    localStorage.removeItem('session');
-    setSessionUser(undefined);
-    router.push('/login');
+  const LogoutUser = async () => {
+    try {
+      await axios.post('/api/logout');
+      localStorage.removeItem('session');
+      setSessionUser(undefined);
+
+      router.push('/login');
+    } catch (error) {
+      throw new Error(`${JSON.stringify(error)}`);
+    }
   };
 
   return (
@@ -70,7 +77,7 @@ const HeaderMenu: FC = () => {
           <ListItemIcon>
             <Logout fontSize='small' />
           </ListItemIcon>
-          <div onClick={logoutUser}>ログアウト</div>
+          <div onClick={LogoutUser}>ログアウト</div>
         </MenuItem>
       </Menu>
     </div>

--- a/pages/api/check-session.ts
+++ b/pages/api/check-session.ts
@@ -1,0 +1,9 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.cookies.access_token) {
+    res.status(200).json({ session: true });
+  } else {
+    res.status(401).json({ session: false });
+  }
+}

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const response = await axios.post(url, { email, password });
     const { access_token, user_id, exp, role } = response.data;
 
-    res.setHeader('Set-Cookie', `access_token=${access_token}; Path=/; Max-Age=3600; HttpOnly; Secure; SameSite=Strict`);
+    res.setHeader('Set-Cookie', `access_token=${access_token}; Path=/; Max-Age=86400; HttpOnly; Secure; SameSite=Strict`);
     res.status(200).json({ access_token, user_id, exp, role });
   } catch (error) {
     if (error instanceof AxiosError) {

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Set-Cookie', 'access_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT; HttpOnly; Secure; SameSite=Strict');
+  res.status(200).json({ message: 'ログアウトに成功しました。' });
+}


### PR DESCRIPTION
## Epic


## PBI
[ログインしていない場合、ログイン画面に遷移する](https://app.asana.com/0/1204548322306328/1205947063398555/f)

## 対象画面キャプチャ


## 実行するコマンド


## やったこと
- セッションの監視とログアウトのAPI作成
- セッションの有効期限を1日に設定して、1日経ったら再ログインを促すようにした
- セッションの有効期限をlocalStrageに依存しないようにクッキー側で管理した

## このPRでやらないこと


## 動作確認
- [x] 確認済み

## その他
- 現状セッション情報の保存場所がないため、localStrageは必要だったので残している