### PR TITLE
無駄なレンダリングを減らして初回画面表示時間を短縮した

### DIFF
--- a/components/organisms/Header.tsx
+++ b/components/organisms/Header.tsx
@@ -12,14 +12,9 @@ import AddIcon from '@mui/icons-material/Add';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 
 const Header: FC = () => {
-  const appContext = useContext(AppContext);
-  const { handleDrawerAreaToggle, handleMenuOpen } = appContext;
-
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
-
-  const formContext = useContext(FormContext);
-  const { setFormOpen, setFormType } = formContext;
+  const { handleDrawerAreaToggle, handleMenuOpen } = useContext(AppContext);
+  const { sessionUser } = useContext(SessionContext);
+  const { setFormOpen, setFormType } = useContext(FormContext);
 
   const handleFormOpen = (formType: FormType) => {
     setFormOpen(true);

--- a/components/organisms/Layout.tsx
+++ b/components/organisms/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect } from 'react';
+import React, { FC, useContext, useEffect, useMemo } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import { LayoutProps } from '@/types/utils';
@@ -18,9 +18,9 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   const sessionContext = useContext(SessionContext);
   const { setSessionUser, sessionUser, setIsAdmin, isAdmin } = sessionContext;
 
-  const mainStyle: React.CSSProperties = {
+  const mainStyle = useMemo(() => ({
     width: drawerArea ? 'calc(100% - 240px)' : '100%',
-  };
+  }), [drawerArea]);
 
   useEffect((): void => {
     const sessionData = getSession();

--- a/components/organisms/Sidebar.tsx
+++ b/components/organisms/Sidebar.tsx
@@ -17,50 +17,28 @@ import CastForEducationIcon from '@mui/icons-material/CastForEducation';
 import TeamList from '../molecules/TeamList';
 import OutputIcon from '@mui/icons-material/Output';
 
-const Sidebar: FC = () => {
-  const appContext = useContext(AppContext);
-  const { drawerArea, handleDrawerAreaToggle } = appContext;
+const ACTIVE_STYLE = {
+  backgroundColor: '#222222',
+};
+const SX = {
+  color: '#DDDDDD',
+  mr: 1
+};
+const FONT_SIZE = 'small';
 
-  const sidebarMenus: sidebarMenus[] = [
-    {
-      id: 'dashboard',
-      label: 'ダッシュボード',
-      value: '/',
-      icon: <DashboardIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'timeline',
-      label: 'タイムライン',
-      value: '/timeline',
-      icon: <FeedIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'mypage',
-      label: 'マイページ',
-      value: '/mypage',
-      icon: <AccountCircleIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'portfolio',
-      label: 'ポートフォリオ',
-      value: '/portfolio',
-      icon: <CastForEducationIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'message',
-      label: 'メッセージ',
-      value: '/message',
-      icon: <MessageIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'outputs',
-      label: 'アウトプット',
-      value: '/outputs',
-      icon: <OutputIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-  ];
+const Sidebar: FC = () => {
+  const { drawerArea } = useContext(AppContext);
   const router = useRouter();
   const isActive = (path: string) => router.pathname === path;
+
+  const menuItems = [
+    { id: 'dashboard', label: 'ダッシュボード', value: '/', icon: <DashboardIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'timeline', label: 'タイムライン', value: '/timeline', icon: <FeedIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'mypage', label: 'マイページ', value: '/mypage', icon: <AccountCircleIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'portfolio', label: 'ポートフォリオ', value: '/portfolio', icon: <CastForEducationIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'message', label: 'メッセージ', value: '/message', icon: <MessageIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'outputs', label: 'アウトプット', value: '/outputs', icon: <OutputIcon sx={SX} fontSize={FONT_SIZE} /> }
+  ];
 
   return (
     <aside className='w-0 h-full'>
@@ -76,22 +54,18 @@ const Sidebar: FC = () => {
         anchor='left'
         open={drawerArea}
       >
-        <div className='bg-gray-700 h-full'>
-          <List>
-            {sidebarMenus.map((menu) => (
-              <ListItem key={menu.id} disablePadding sx={isActive(menu.value) ? { backgroundColor: '#222222' } : {}}>
-                <ListItemButton>
-                  {menu.icon}
-                  <Link href={menu.value} className='text-sm text-gray-200'>
-                    {menu.label}
-                  </Link>
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
+        <List className='bg-gray-700 h-full'>
+          {menuItems.map((menu) => (
+            <ListItem key={menu.id} disablePadding sx={isActive(menu.value) ? ACTIVE_STYLE : {}}>
+              <ListItemButton onClick={() => router.push(menu.value)}>
+                {menu.icon}
+                <span className='text-sm text-gray-200'>{menu.label}</span>
+              </ListItemButton>
+            </ListItem>
+          ))}
           <Divider className='bg-gray-500' />
           <TeamList />
-        </div>
+        </List>
       </Drawer>
     </aside>
   );

--- a/components/templates/DashboardWrapper.tsx
+++ b/components/templates/DashboardWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useMemo } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import Chart from '@/components/uikit/Chart';
 import RankTable from '@/components/uikit/RankTable';
 import { StackProps } from '@/types/stack';
@@ -6,153 +6,124 @@ import axios from 'axios';
 import { getApiHeadersWithUserId } from '@/utiliry/api';
 
 const DashboardWrapper: FC = () => {
-  const [stacks, setStacks] = useState<StackProps[]>([]);
   const currentDate = new Date();
   const currentYear = currentDate.getFullYear();
   const currentMonth = currentDate.getMonth() + 1;
-  const daysInMonth = new Date(currentYear, currentMonth, 0).getDate();
-
-  const fetchStacksData = async () => {
-    try {
-      const options = getApiHeadersWithUserId();
-      const response = await axios.get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options);
-      setStacks(response.data.stacks);
-    } catch (error) {
-      console.error('Error fetching stack data:', error);
+  const daysInMonth = currentDate.getDate();
+  const generateLabels = (daysInMonth: number): string[] => {
+    const stackLabels: string[] = [];
+    for (let i = 1; i <= daysInMonth; i++) {
+      stackLabels.push(i.toString());
     }
+    return stackLabels;
   };
+  const barLabels = generateLabels(daysInMonth);
+
+  const [stacks, setStacks] = useState<StackProps[]>([]);
+  const [barData, setBarData] = useState<number[]>([]);
+  const [pieData, setPieData] = useState<number[]>([]);
+  const [pieLabels, setPieLabels] = useState<string[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    fetchStacksData();
-  }, []);
+    const fetchData = async () => {
+      try {
+        const options = getApiHeadersWithUserId();
+        const response = await axios.get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options);
+        const { data } = response;
 
-  const barLabels = useMemo(() => Array.from({ length: daysInMonth }, (_, i) => (i + 1).toString()), [daysInMonth]);
+        const aggregatedData = new Array(daysInMonth).fill(0);
 
-  const barData = useMemo(() => {
-    const aggregatedData = new Array(daysInMonth).fill(0);
-    stacks.forEach((stack) => {
-      const stackDate = new Date(stack.stacked_at);
-      if (stackDate.getFullYear() === currentYear && stackDate.getMonth() + 1 === currentMonth) {
-        aggregatedData[stackDate.getDate() - 1] += stack.minutes;
+        data.stacks.forEach((stack: StackProps) => {
+          const stackDate = new Date(stack.stacked_at);
+          const stackYear = stackDate.getFullYear();
+          const stackMonth = stackDate.getMonth() + 1;
+          const stackDay = stackDate.getDate();
+
+          const minutes = stack.minutes;
+
+          if (stackYear === currentYear && stackMonth === currentMonth) {
+            aggregatedData[stackDay - 1] += minutes;
+          }
+        });
+
+        setStacks(data.stacks);
+        setBarData(aggregatedData);
+        setLoading(false);
+      } catch (error) {
+        throw new Error(`${JSON.stringify(error)}`);
       }
-    });
-    return aggregatedData;
-  }, [stacks, currentYear, currentMonth, daysInMonth]);
+    };
 
-  const pieData = useMemo(() => {
-    const skillMinutesMap = stacks.reduce((acc, stack) => {
+    fetchData();
+  }, [currentYear, currentMonth, daysInMonth]);
+
+  useEffect(() => {
+    if (!stacks.length) return;
+
+    const skillMinutesMap: { [key: string]: number } = {};
+    stacks.forEach((stack) => {
       const skillName = stack.skill.name;
-      acc[skillName] = (acc[skillName] || 0) + stack.minutes;
-      return acc;
-    }, {});
+      const minutes = stack.minutes;
+      skillMinutesMap[skillName] = (skillMinutesMap[skillName] || 0) + minutes;
+    });
+
     const totalMinutes = Object.values(skillMinutesMap).reduce((acc, curr) => acc + curr, 0);
-    return Object.keys(skillMinutesMap).map((label) => skillMinutesMap[label] / totalMinutes);
+    const skillLabels = Object.keys(skillMinutesMap);
+    const skillData = skillLabels.map((label) => skillMinutesMap[label] / totalMinutes);
+
+    setPieData(skillData);
+    setPieLabels(skillLabels);
   }, [stacks]);
-
-  const pieLabels = useMemo(() => {
-    return Object.keys(stacks.reduce((acc, stack) => {
-      acc[stack.skill.name] = true;
-      return acc;
-    }, {}));
-  }, [stacks]);
-
-
-  // const barLabels = generateLabels(daysInMonth);
-
-  // useEffect(() => {
-  //   const options = getApiHeadersWithUserId();
-  //   axios
-  //     .get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options)
-  //     .then((response) => {
-  //       const { data } = response;
-  //       setStacks(data.stacks);
-
-  //       const aggregatedData = new Array(daysInMonth).fill(0);
-
-  //       data.stacks.forEach((stack: StackProps) => {
-  //         const stackDate = new Date(stack.stacked_at);
-  //         const stackYear = stackDate.getFullYear();
-  //         const stackMonth = stackDate.getMonth() + 1;
-  //         const stackDay = stackDate.getDate();
-
-  //         const minutes = stack.minutes;
-
-  //         if (stackYear === currentYear && stackMonth === currentMonth) {
-  //           aggregatedData[stackDay - 1] += minutes;
-  //         }
-  //       });
-  //       setBarData(aggregatedData);
-  //     })
-  //     .catch((error) => {
-  //       if (error.response) {
-  //         const { data } = error.response;
-  //         throw new Error(`${JSON.stringify(data)}`);
-  //       } else {
-  //         throw new Error(`${JSON.stringify(error)}`);
-  //       }
-  //     });
-  // }, []);
-
-  // useEffect(() => {
-  //   if (!stacks.length) return;
-
-  //   const skillMinutesMap: { [key: string]: number } = {};
-  //   stacks.forEach((stack) => {
-  //     const skillName = stack.skill.name;
-  //     const minutes = stack.minutes;
-  //     skillMinutesMap[skillName] = (skillMinutesMap[skillName] || 0) + minutes;
-  //   });
-
-  //   const totalMinutes = Object.values(skillMinutesMap).reduce((acc, curr) => acc + curr, 0);
-  //   const skillLabels = Object.keys(skillMinutesMap);
-  //   const skillData = skillLabels.map((label) => skillMinutesMap[label] / totalMinutes);
-
-  //   setPieData(skillData);
-  //   setPieLabels(skillLabels);
-  // }, [stacks]);
 
   return (
     <div className='max-w-[1020px] m-auto'>
-      <div className='bg-white rounded-md shadow-sm border border-gray-300'>
-        <div className='p-6 text-md text-gray-700 border-b-2 border-gray-100'>積み上げ時間</div>
-        <div className='px-6 pt-6 pb-10'>
-          <Chart
-            labels={barLabels}
-            label={'時間'}
-            data={barData}
-            bdColor={['rgb(39, 119, 169)']}
-            bgColor={['rgb(240, 248, 250)']}
-            bdwidth={1}
-            text={currentMonth + '月の学習時間'}
-            type={'bar'}
-            pattern={'StackTimeGraph'}
-          />
-        </div>
-      </div>
-      <div className='bg-white rounded-md shadow-sm border border-gray-300 mt-8'>
-        <div className='p-6 text-md text-gray-700 border-b-2 border-gray-100'>積み上げスキル</div>
-        <div className='p-6 pb-10 flex justify-center'>
-          <div className='w-[50%]'>
-            <Chart
-              labels={pieLabels}
-              label={'学習時間'}
-              data={pieData}
-              bdColor={['rgb(39, 119, 169)']}
-              bgColor={['rgb(240, 248, 250)']}
-              bdwidth={1}
-              text={'積み上げスキル'}
-              type={'pie'}
-              pattern={'StackSkillGraph'}
-            />
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <>
+          <div className='bg-white rounded-md shadow-sm border border-gray-300'>
+            <div className='p-6 text-md text-gray-700 border-b-2 border-gray-100'>積み上げ時間</div>
+            <div className='px-6 pt-6 pb-10'>
+              <Chart
+                labels={barLabels}
+                label={'時間'}
+                data={barData}
+                bdColor={['rgb(39, 119, 169)']}
+                bgColor={['rgb(240, 248, 250)']}
+                bdwidth={1}
+                text={currentMonth + '月の学習時間'}
+                type={'bar'}
+                pattern={'StackTimeGraph'}
+              />
+            </div>
           </div>
-        </div>
-      </div>
-      <div className='bg-white rounded-md shadow-sm border border-gray-300 mt-8'>
-        <div className='p-6 text-md text-gray-700 border-b-2 border-gray-100'>積み上げランキング</div>
-        <div className='p-6'>
-          <RankTable />
-        </div>
-      </div>
+          <div className='bg-white rounded-md shadow-sm border border-gray-300 mt-8'>
+            <div className='p-6 text-md text-gray-700 border-b-2 border-gray-100'>積み上げスキル</div>
+            <div className='p-6 pb-10 flex justify-center'>
+              <div className='w-[50%]'>
+                <Chart
+                  labels={pieLabels}
+                  label={'学習時間'}
+                  data={pieData}
+                  bdColor={['rgb(39, 119, 169)']}
+                  bgColor={['rgb(240, 248, 250)']}
+                  bdwidth={1}
+                  text={'積み上げスキル'}
+                  type={'pie'}
+                  pattern={'StackSkillGraph'}
+                />
+              </div>
+            </div>
+          </div>
+          <div className='bg-white rounded-md shadow-sm border border-gray-300 mt-8'>
+            <div className='p-6 text-md text-gray-700 border-b-2 border-gray-100'>積み上げランキング</div>
+            <div className='p-6'>
+              <RankTable />
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/components/templates/DashboardWrapper.tsx
+++ b/components/templates/DashboardWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState, useMemo } from 'react';
 import Chart from '@/components/uikit/Chart';
 import RankTable from '@/components/uikit/RankTable';
 import { StackProps } from '@/types/stack';
@@ -7,76 +7,109 @@ import { getApiHeadersWithUserId } from '@/utiliry/api';
 
 const DashboardWrapper: FC = () => {
   const [stacks, setStacks] = useState<StackProps[]>([]);
-  const [barData, setBarData] = useState<number[]>([]);
-  const [pieData, setPieData] = useState<number[]>([]);
-  const [pieLabels, setPieLabels] = useState<string[]>([]);
-
   const currentDate = new Date();
   const currentYear = currentDate.getFullYear();
   const currentMonth = currentDate.getMonth() + 1;
-  const daysInMonth = currentDate.getDate();
+  const daysInMonth = new Date(currentYear, currentMonth, 0).getDate();
 
-  const generateLabels = (daysInMonth: number): string[] => {
-    const stackLabels: string[] = [];
-    for (let i = 1; i <= daysInMonth; i++) {
-      stackLabels.push(i.toString());
+  const fetchStacksData = async () => {
+    try {
+      const options = getApiHeadersWithUserId();
+      const response = await axios.get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options);
+      setStacks(response.data.stacks);
+    } catch (error) {
+      console.error('Error fetching stack data:', error);
     }
-    return stackLabels;
   };
 
-  const barLabels = generateLabels(daysInMonth);
-
   useEffect(() => {
-    const options = getApiHeadersWithUserId();
-    axios
-      .get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options)
-      .then((response) => {
-        const { data } = response;
-        setStacks(data.stacks);
-
-        const aggregatedData = new Array(daysInMonth).fill(0);
-
-        data.stacks.forEach((stack: StackProps) => {
-          const stackDate = new Date(stack.stacked_at);
-          const stackYear = stackDate.getFullYear();
-          const stackMonth = stackDate.getMonth() + 1;
-          const stackDay = stackDate.getDate();
-
-          const minutes = stack.minutes;
-
-          if (stackYear === currentYear && stackMonth === currentMonth) {
-            aggregatedData[stackDay - 1] += minutes;
-          }
-        });
-        setBarData(aggregatedData);
-      })
-      .catch((error) => {
-        if (error.response) {
-          const { data } = error.response;
-          throw new Error(`${JSON.stringify(data)}`);
-        } else {
-          throw new Error(`${JSON.stringify(error)}`);
-        }
-      });
+    fetchStacksData();
   }, []);
 
-  useEffect(() => {
-    if (!stacks.length) return;
+  const barLabels = useMemo(() => Array.from({ length: daysInMonth }, (_, i) => (i + 1).toString()), [daysInMonth]);
 
-    const skillMinutesMap: { [key: string]: number } = {};
+  const barData = useMemo(() => {
+    const aggregatedData = new Array(daysInMonth).fill(0);
     stacks.forEach((stack) => {
-      const skillName = stack.skill.name;
-      const minutes = stack.minutes;
-      skillMinutesMap[skillName] = (skillMinutesMap[skillName] || 0) + minutes;
+      const stackDate = new Date(stack.stacked_at);
+      if (stackDate.getFullYear() === currentYear && stackDate.getMonth() + 1 === currentMonth) {
+        aggregatedData[stackDate.getDate() - 1] += stack.minutes;
+      }
     });
+    return aggregatedData;
+  }, [stacks, currentYear, currentMonth, daysInMonth]);
 
+  const pieData = useMemo(() => {
+    const skillMinutesMap = stacks.reduce((acc, stack) => {
+      const skillName = stack.skill.name;
+      acc[skillName] = (acc[skillName] || 0) + stack.minutes;
+      return acc;
+    }, {});
     const totalMinutes = Object.values(skillMinutesMap).reduce((acc, curr) => acc + curr, 0);
-    const skillLabels = Object.keys(skillMinutesMap);
-    const skillData = skillLabels.map((label) => skillMinutesMap[label] / totalMinutes);
-
-    setPieData(skillData);
-    setPieLabels(skillLabels);
+    return Object.keys(skillMinutesMap).map((label) => skillMinutesMap[label] / totalMinutes);
   }, [stacks]);
+
+  const pieLabels = useMemo(() => {
+    return Object.keys(stacks.reduce((acc, stack) => {
+      acc[stack.skill.name] = true;
+      return acc;
+    }, {}));
+  }, [stacks]);
+
+
+  // const barLabels = generateLabels(daysInMonth);
+
+  // useEffect(() => {
+  //   const options = getApiHeadersWithUserId();
+  //   axios
+  //     .get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options)
+  //     .then((response) => {
+  //       const { data } = response;
+  //       setStacks(data.stacks);
+
+  //       const aggregatedData = new Array(daysInMonth).fill(0);
+
+  //       data.stacks.forEach((stack: StackProps) => {
+  //         const stackDate = new Date(stack.stacked_at);
+  //         const stackYear = stackDate.getFullYear();
+  //         const stackMonth = stackDate.getMonth() + 1;
+  //         const stackDay = stackDate.getDate();
+
+  //         const minutes = stack.minutes;
+
+  //         if (stackYear === currentYear && stackMonth === currentMonth) {
+  //           aggregatedData[stackDay - 1] += minutes;
+  //         }
+  //       });
+  //       setBarData(aggregatedData);
+  //     })
+  //     .catch((error) => {
+  //       if (error.response) {
+  //         const { data } = error.response;
+  //         throw new Error(`${JSON.stringify(data)}`);
+  //       } else {
+  //         throw new Error(`${JSON.stringify(error)}`);
+  //       }
+  //     });
+  // }, []);
+
+  // useEffect(() => {
+  //   if (!stacks.length) return;
+
+  //   const skillMinutesMap: { [key: string]: number } = {};
+  //   stacks.forEach((stack) => {
+  //     const skillName = stack.skill.name;
+  //     const minutes = stack.minutes;
+  //     skillMinutesMap[skillName] = (skillMinutesMap[skillName] || 0) + minutes;
+  //   });
+
+  //   const totalMinutes = Object.values(skillMinutesMap).reduce((acc, curr) => acc + curr, 0);
+  //   const skillLabels = Object.keys(skillMinutesMap);
+  //   const skillData = skillLabels.map((label) => skillMinutesMap[label] / totalMinutes);
+
+  //   setPieData(skillData);
+  //   setPieLabels(skillLabels);
+  // }, [stacks]);
 
   return (
     <div className='max-w-[1020px] m-auto'>

--- a/components/templates/MyPageWrapper.tsx
+++ b/components/templates/MyPageWrapper.tsx
@@ -1,10 +1,9 @@
 import React, { FC, useEffect, useState } from 'react';
-import { tabInfo } from '../../sample';
-import StackCard from '../molecules/StackCard';
-import ProfileCard from '../molecules/ProfileCard';
 import axios from 'axios';
 import { StackProps } from '@/types/stack';
 import { getApiHeadersWithUserId } from '@/utiliry/api';
+import ProfileCard from '../molecules/ProfileCard';
+import StackCard from '../molecules/StackCard';
 import Chart from '../uikit/Chart';
 
 const MyPageWrapper: FC = () => {
@@ -24,38 +23,35 @@ const MyPageWrapper: FC = () => {
   // };
 
   useEffect(() => {
-    const options = getApiHeadersWithUserId();
-    axios
-      .get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options)
-      .then((response) => {
+    const fetchData = async () => {
+      try {
+        const options = getApiHeadersWithUserId();
+        const response = await axios.get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options);
         const { data } = response;
         setStacks(data.stacks);
-      })
-      .catch((error) => {
+
+        const skillAccumulation: { [skill: string]: number } = {};
+        data.stacks.forEach((stack) => {
+          const { skill, minutes } = stack;
+          skillAccumulation[skill.name] = (skillAccumulation[skill.name] || 0) + minutes;
+        });
+
+        const skillNames = Object.keys(skillAccumulation);
+        const skillMinutes = Object.values(skillAccumulation);
+        setSkills(skillNames);
+        setMinutes(skillMinutes);
+      } catch (error) {
         if (error.response) {
           const { data } = error.response;
-          throw new Error(`${JSON.stringify(data)}`);
+          console.error(`${JSON.stringify(data)}`);
         } else {
-          throw new Error(`${JSON.stringify(error)}`);
+          console.error(`${JSON.stringify(error)}`);
         }
-      });
-  }, []);
-
-  useEffect(() => {
-    const skillAccumulation: { [skill: string]: number } = {};
-
-    stacks.forEach((stack) => {
-      const { skill, minutes } = stack;
-      if (skillAccumulation[skill.name]) {
-        skillAccumulation[skill.name] += minutes;
-      } else {
-        skillAccumulation[skill.name] = minutes;
       }
-    });
+    };
 
-    setSkills(Object.keys(skillAccumulation));
-    setMinutes(Object.values(skillAccumulation));
-  }, [stacks]);
+    fetchData();
+  }, []);
 
   return (
     <div className='max-w-[1020px] m-auto'>

--- a/components/templates/OutputsWrapper.tsx
+++ b/components/templates/OutputsWrapper.tsx
@@ -4,8 +4,7 @@ import OutputCard from '../molecules/OutputCard';
 import { OutputProps, OutputsProps } from '@/types/output';
 
 const OutputsWrapper: FC<OutputsProps> = ({ outputs }) => {
-  const formContext = useContext(FormContext);
-  const { setFormOpen, setFormType } = formContext;
+  const { setFormOpen, setFormType } = useContext(FormContext);
 
   const handleFormOpen = () => {
     setFormType('createOutput');
@@ -21,7 +20,7 @@ const OutputsWrapper: FC<OutputsProps> = ({ outputs }) => {
         アウトプット追加
       </button>
       <div className='flex justify-between flex-wrap mt-8'>
-        {outputs ? (
+        {outputs && outputs.length > 0 ? (
           outputs.map((output: OutputProps) => <OutputCard key={output.id} output={output} />)
         ) : (
           <p>アウトプットがありません。</p>

--- a/components/uikit/HeaderMenu.tsx
+++ b/components/uikit/HeaderMenu.tsx
@@ -9,6 +9,12 @@ import { AppContext } from '@/context/AppContext';
 import { SessionContext } from '@/context/SessionContext';
 import axios from 'axios';
 
+interface MenuItemInfo {
+  icon: React.ReactNode;
+  text: string;
+  action: () => void;
+}
+
 const HeaderMenu: FC = () => {
   const appContext = useContext(AppContext);
   const { anchorEl, handleMenuClose } = appContext;
@@ -16,10 +22,9 @@ const HeaderMenu: FC = () => {
   const sessionContext = useContext(SessionContext);
   const { setSessionUser } = sessionContext;
 
-  const open = Boolean(anchorEl);
   const router = useRouter();
 
-  const LogoutUser = async () => {
+  const logoutUser = async () => {
     try {
       await axios.post('/api/logout');
       localStorage.removeItem('session');
@@ -31,11 +36,24 @@ const HeaderMenu: FC = () => {
     }
   };
 
+  const menuItems: MenuItemInfo[] = [
+    {
+      icon: <Settings fontSize='small' />,
+      text: '設定',
+      action: handleMenuClose,
+    },
+    {
+      icon: <Logout fontSize='small' />,
+      text: 'ログアウト',
+      action: logoutUser,
+    },
+  ];
+
   return (
     <div>
       <Menu
         anchorEl={anchorEl}
-        open={open}
+        open={Boolean(anchorEl)}
         onClose={handleMenuClose}
         onClick={handleMenuClose}
         PaperProps={{
@@ -67,21 +85,15 @@ const HeaderMenu: FC = () => {
         transformOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
-        <MenuItem onClick={handleMenuClose}>
-          <ListItemIcon>
-            <Settings fontSize='small' />
-          </ListItemIcon>
-          設定
-        </MenuItem>
-        <MenuItem onClick={handleMenuClose}>
-          <ListItemIcon>
-            <Logout fontSize='small' />
-          </ListItemIcon>
-          <div onClick={LogoutUser}>ログアウト</div>
-        </MenuItem>
+        {menuItems.map((item, index) => (
+          <MenuItem key={index} onClick={item.action}>
+            <ListItemIcon>{item.icon}</ListItemIcon>
+            {item.text}
+          </MenuItem>
+        ))}
       </Menu>
     </div>
   );
 };
 
-export default HeaderMenu;
+export default React.memo(HeaderMenu);

--- a/components/uikit/RankTable.tsx
+++ b/components/uikit/RankTable.tsx
@@ -1,5 +1,4 @@
-import React, { FC, useContext, useEffect, useState } from 'react';
-
+import React, { FC, useContext, useEffect, useMemo, useState, useCallback } from 'react';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -22,8 +21,8 @@ export type StackRankingColumn = {
 };
 
 const RankTable: FC = () => {
-  const [page, setPage] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(10);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
 
   const sessionContext = useContext(SessionContext);
   const { sessionUser } = sessionContext;
@@ -35,19 +34,37 @@ const RankTable: FC = () => {
     { id: 'user_name', label: 'ユーザー名' },
   ];
 
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handleChangePage = useCallback((event: unknown, newPage: number) => {
     setPage(newPage);
-  };
+  }, []);
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeRowsPerPage = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(+event.target.value);
     setPage(0);
-  };
+  }, []);
 
   useEffect(() => {
-    const options = getApiHeaders();
-    callFetchStackRankings({ options, sessionUser, setStackRankings });
+    const fetchData = async () => {
+      try {
+        const options = getApiHeaders();
+        callFetchStackRankings({ options, sessionUser, setStackRankings });
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchData();
   }, [sessionUser]);
+
+  const paginatedData = useMemo(() => {
+    if (!stackRankings) {
+      return [];
+    }
+
+    const startIndex = page * rowsPerPage;
+    const endIndex = startIndex + rowsPerPage;
+    return stackRankings.slice(startIndex, endIndex);
+  }, [page, rowsPerPage, stackRankings]);
 
   return (
     <>
@@ -63,16 +80,13 @@ const RankTable: FC = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {stackRankings.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((row) => {
-              return (
-                <TableRow hover role='checkbox' tabIndex={-1} key={row.order}>
-                  {StackRankingColumns.map((column) => {
-                    const value = row[column.id];
-                    return <TableCell key={column.id}>{value}</TableCell>;
-                  })}
-                </TableRow>
-              );
-            })}
+            {paginatedData.map((row) => (
+              <TableRow hover role='checkbox' tabIndex={-1} key={row.order}>
+                {StackRankingColumns.map((column) => (
+                  <TableCell key={column.id}>{row[column.id]}</TableCell>
+                ))}
+              </TableRow>
+            ))}
           </TableBody>
         </Table>
       </TableContainer>

--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, createContext, useState } from 'react';
+import React, { MouseEvent, createContext, useState, useCallback, useMemo } from 'react';
 import { ChildrenProps } from '@/types/utils';
 import { AppContextProps } from '@/types/context';
 
@@ -16,30 +16,30 @@ const AppContext = createContext<AppContextProps>(InitialState);
 
 const AppProvider = ({ children }: ChildrenProps) => {
   const [drawerArea, setDrawerArea] = useState<boolean>(true);
-  const handleDrawerAreaToggle: () => void = () => {
-    setDrawerArea(!drawerArea);
-  };
+  const handleDrawerAreaToggle = useCallback(() => {
+    setDrawerArea(prevDrawerArea => !prevDrawerArea);
+  }, []);
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const handleMenuOpen = (event: MouseEvent<HTMLElement>) => {
+  const handleMenuOpen = useCallback((event: MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
-  };
-  const handleMenuClose: () => void = () => {
+  }, []);
+  const handleMenuClose = useCallback(() => {
     setAnchorEl(null);
-  };
+  }, []);
+
+  const providerValue = useMemo(() => ({
+    drawerArea,
+    setDrawerArea,
+    handleDrawerAreaToggle,
+    anchorEl,
+    setAnchorEl,
+    handleMenuOpen,
+    handleMenuClose,
+  }), [drawerArea, anchorEl]);
 
   return (
-    <AppContext.Provider
-      value={{
-        drawerArea: drawerArea,
-        setDrawerArea: setDrawerArea,
-        handleDrawerAreaToggle: handleDrawerAreaToggle,
-        anchorEl: anchorEl,
-        setAnchorEl: setAnchorEl,
-        handleMenuOpen: handleMenuOpen,
-        handleMenuClose: handleMenuClose,
-      }}
-    >
+    <AppContext.Provider value={providerValue}>
       {children}
     </AppContext.Provider>
   );

--- a/context/FormContext.tsx
+++ b/context/FormContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useMemo } from 'react';
 import { ChildrenProps } from '@/types/utils';
 import { FormType } from '@/types/form';
 import { FormContextProps } from '@/types/context';
@@ -22,19 +22,19 @@ const FormProvider = ({ children }: ChildrenProps) => {
   const [isRegisterEvent, setIsRegisterEvent] = useState<boolean>(false);
   const [isValidate, setIsValidate] = useState<boolean>(true);
 
+  const providerValue = useMemo(() => ({
+    formType,
+    setFormType,
+    formOpen,
+    setFormOpen,
+    isRegisterEvent,
+    setIsRegisterEvent,
+    isValidate,
+    setIsValidate,
+  }), [formType, formOpen, isRegisterEvent, isValidate]);
+
   return (
-    <FormContext.Provider
-      value={{
-        formType: formType,
-        setFormType: setFormType,
-        formOpen: formOpen,
-        setFormOpen: setFormOpen,
-        isRegisterEvent: isRegisterEvent,
-        setIsRegisterEvent: setIsRegisterEvent,
-        isValidate: isValidate,
-        setIsValidate: setIsValidate,
-      }}
-    >
+    <FormContext.Provider value={providerValue}>
       {children}
     </FormContext.Provider>
   );

--- a/context/FormDataContext.tsx
+++ b/context/FormDataContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useMemo } from 'react';
 import { ChildrenProps } from '@/types/utils';
 import { IntrospectionProps } from '@/types/introspection';
 import {
@@ -54,27 +54,27 @@ const FormDataProvider = ({ children }: ChildrenProps) => {
   const [outputCommentFormData, setOutputCommentFormData] =
     useState<OutputCommentFormDataParams>(InitialOutputCommentFormData);
 
+  const providerValue = useMemo(() => ({
+    teamFormData,
+    setTeamFormData,
+    inviteTeamFormData,
+    setInviteTeamFormData,
+    userFormData,
+    setUserFormData,
+    stackFormData,
+    setStackFormData,
+    introspectionFormData,
+    setIntrospectionFormData,
+    showStackIntrospection,
+    setShowStackIntrospection,
+    outputFormData,
+    setOutputFormData,
+    outputCommentFormData,
+    setOutputCommentFormData,
+  }), [teamFormData, inviteTeamFormData, userFormData, stackFormData, introspectionFormData, showStackIntrospection, outputFormData, outputCommentFormData]);
+
   return (
-    <FormDataContext.Provider
-      value={{
-        teamFormData: teamFormData,
-        setTeamFormData: setTeamFormData,
-        inviteTeamFormData: inviteTeamFormData,
-        setInviteTeamFormData: setInviteTeamFormData,
-        userFormData: userFormData,
-        setUserFormData: setUserFormData,
-        stackFormData: stackFormData,
-        setStackFormData: setStackFormData,
-        introspectionFormData: introspectionFormData,
-        setIntrospectionFormData: setIntrospectionFormData,
-        showStackIntrospection: showStackIntrospection,
-        setShowStackIntrospection: setShowStackIntrospection,
-        outputFormData: outputFormData,
-        setOutputFormData: setOutputFormData,
-        outputCommentFormData: outputCommentFormData,
-        setOutputCommentFormData: setOutputCommentFormData,
-      }}
-    >
+    <FormDataContext.Provider value={providerValue}>
       {children}
     </FormDataContext.Provider>
   );

--- a/context/SessionContext.tsx
+++ b/context/SessionContext.tsx
@@ -1,14 +1,7 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useMemo } from 'react';
 import { ChildrenProps } from '@/types/utils';
 import { sessionUser } from '@/types/session';
 import { SessionContextProps } from '@/types/context';
-
-const InitialState: SessionContextProps = {
-  sessionUser: undefined,
-  setSessionUser: () => {},
-  isAdmin: false,
-  setIsAdmin: () => {},
-};
 
 const SessionContext = createContext<SessionContextProps>(InitialState);
 
@@ -16,15 +9,15 @@ const SessionProvider = ({ children }: ChildrenProps) => {
   const [sessionUser, setSessionUser] = useState<sessionUser>(undefined);
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
+  const providerValue = useMemo(() => ({
+    sessionUser,
+    setSessionUser,
+    isAdmin,
+    setIsAdmin,
+  }), [sessionUser, isAdmin]);
+
   return (
-    <SessionContext.Provider
-      value={{
-        sessionUser: sessionUser,
-        setSessionUser: setSessionUser,
-        isAdmin: isAdmin,
-        setIsAdmin: setIsAdmin,
-      }}
-    >
+    <SessionContext.Provider value={providerValue}>
       {children}
     </SessionContext.Provider>
   );

--- a/context/SessionContext.tsx
+++ b/context/SessionContext.tsx
@@ -3,6 +3,13 @@ import { ChildrenProps } from '@/types/utils';
 import { sessionUser } from '@/types/session';
 import { SessionContextProps } from '@/types/context';
 
+const InitialState: SessionContextProps = {
+  sessionUser: undefined,
+  setSessionUser: () => {},
+  isAdmin: false,
+  setIsAdmin: () => {},
+};
+
 const SessionContext = createContext<SessionContextProps>(InitialState);
 
 const SessionProvider = ({ children }: ChildrenProps) => {

--- a/context/SnackbarContext.tsx
+++ b/context/SnackbarContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, FC } from 'react';
+import React, { createContext, useState, useCallback } from 'react';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import { ChildrenProps } from '@/types/utils';
@@ -16,23 +16,24 @@ const SnackbarProvider = ({ children }: ChildrenProps) => {
   const [severity, setSeverity] = useState<SnackbarSeverity>('info');
   const [message, setMessage] = useState<string>('');
 
-  const showSnackbar = (type: SnackbarSeverity, message: string): void => {
+  const showSnackbar = useCallback((type: SnackbarSeverity, message: string): void => {
     setOpen(true);
     setSeverity(type);
     setMessage(message);
-  };
+  }, []);
 
-  const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
+  const handleClose = useCallback((event: React.SyntheticEvent | Event, reason?: string) => {
     if (reason === 'clickaway') {
       return;
     }
-
     setOpen(false);
-  };
+  }, []);
 
   return (
     <>
-      <SnackbarContext.Provider value={{ showSnackbar: showSnackbar }}>{children}</SnackbarContext.Provider>
+      <SnackbarContext.Provider value={{ showSnackbar: showSnackbar }}>
+        {children}
+      </SnackbarContext.Provider>
       <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
         <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
           {message}

--- a/pages/outputs/[output].tsx
+++ b/pages/outputs/[output].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useState, useContext, useCallback } from 'react';
 import axios from 'axios';
 import cookie from 'cookie';
 import { GetServerSideProps, NextPage } from 'next';
@@ -13,6 +13,7 @@ import { FormDataContext } from '@/context/FormDataContext';
 const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
   const router = useRouter();
   const handleBack = () => router.back();
+  const [comments, setComments] = useState(initialComments);
 
   const formContext = useContext(FormContext);
   const { setFormOpen, setFormType } = formContext;
@@ -20,12 +21,16 @@ const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
   const formDataContext = useContext(FormDataContext);
   const { setOutputCommentFormData } = formDataContext;
 
-  const handleFormOpen = () => {
+  const handleFormOpen = useCallback(() => {
     const outputId = output.id;
     setOutputCommentFormData({ ...InitialOutputCommentFormData, outputId });
     setFormType('createOutputComment');
     setFormOpen(true);
-  };
+  }, []);
+
+  useEffect(() => {
+    setComments(initialComments);
+  }, [initialComments]);
 
   return (
     <div className='bg-gray-50 h-full min-h-screen flex justify-center items-center'>
@@ -37,7 +42,9 @@ const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
         <button className='block bg-blue-500 text-blue-100 hover:bg-blue-600 text-sm font-bold rounded-full p-2 ml-auto w-[150px] text-center cursor-pointer' onClick={handleFormOpen}>コメントする</button>
         <div className='p-4 bg-white'>
           <h2 className='text-lg font-bold mb-4'>コメント</h2>
-          <CommentList comments={initialComments} />
+          {comments && comments.map((comment) => (
+            <Comment key={comment.id} comment={comment} />
+          ))}
         </div>
         <FormModal />
       </div>

--- a/pages/outputs/index.tsx
+++ b/pages/outputs/index.tsx
@@ -1,23 +1,23 @@
-import React from 'react'
-import axios from 'axios'
-import Layout from '@/components/organisms/Layout'
-import OutputsWrapper from '@/components/templates/OutputsWrapper'
-import { GetServerSideProps, NextPage } from 'next'
+import React from 'react';
+import axios from 'axios';
+import Layout from '@/components/organisms/Layout';
+import OutputsWrapper from '@/components/templates/OutputsWrapper';
+import { GetServerSideProps, NextPage } from 'next';
 import cookie from 'cookie';
-import { getNextApiHeaders } from '@/utiliry/api'
-import { OutputsProps } from '@/types/output'
+import { getNextApiHeaders } from '@/utiliry/api';
+import { OutputsProps } from '@/types/output';
 
-const index: NextPage<OutputsProps> = ({ outputs }) => {
+const Index: NextPage<OutputsProps> = ({ outputs }) => {
   return (
     <div>
       <Layout>
         <OutputsWrapper outputs={outputs} />
       </Layout>
     </div>
-  )
-}
+  );
+};
 
-export default index
+export default Index;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   try {
@@ -39,4 +39,4 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     console.error('Error fetching data:', error);
     return { props: {} };
   }
-}
+};

--- a/pages/timeline/index.tsx
+++ b/pages/timeline/index.tsx
@@ -1,18 +1,18 @@
-import React, { useContext, useEffect, useState } from 'react'
-import { NextPage } from 'next'
-import Layout from '@/components/organisms/Layout'
-import StackList from '@/components/molecules/StackList'
-import { StackProps } from '@/types/stack'
-import { getSession } from '@/utiliry/session'
-import { ApiOptions } from '@/types/api'
-import { SessionContext } from '@/context/SessionContext'
-import axios from 'axios'
+import React, { useContext, useEffect, useState } from 'react';
+import { NextPage } from 'next';
+import Layout from '@/components/organisms/Layout';
+import StackList from '@/components/molecules/StackList';
+import { StackProps } from '@/types/stack';
+import { getSession } from '@/utiliry/session';
+import { ApiOptions } from '@/types/api';
+import { SessionContext } from '@/context/SessionContext';
+import axios from 'axios';
 
 const Index: NextPage = () => {
-  const [stacks, setStacks] = useState<StackProps[]>([]);
-  
   const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext
+  const { sessionUser } = sessionContext;
+
+  const [stacks, setStacks] = useState<StackProps[]>([]);
 
   useEffect(() => {
     const sessionData = getSession();
@@ -22,11 +22,11 @@ const Index: NextPage = () => {
       const options: ApiOptions = {
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${sessionData.token}`
+          Authorization: `Bearer ${sessionData.token}`,
         },
-        params: { team_id: sessionUser?.team.id }
+        params: { team_id: sessionUser?.team.id },
       };
-      const url = `${process.env.API_ROOT_URL}/api/v1/stacks`
+      const url = `${process.env.API_ROOT_URL}/api/v1/stacks`;
 
       try {
         const response = await axios.get(url, options);
@@ -36,14 +36,19 @@ const Index: NextPage = () => {
       }
     };
 
-    fetchStacks().then((res) => { setStacks(res); });
-  }, [stacks]);
+    const fetchData = async () => {
+      const fetchedStacks = await fetchStacks();
+      setStacks(fetchedStacks);
+    };
+
+    fetchData();
+  }, [sessionUser]);
 
   return (
     <Layout>
       <StackList stacks={stacks} />
     </Layout>
-  )
-}
+  );
+};
 
-export default Index
+export default Index;

--- a/pages/users/register.tsx
+++ b/pages/users/register.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useContext } from 'react';
 import axios from 'axios';
 import { GetServerSideProps, NextPage } from 'next'
 import { useRouter } from 'next/router';
@@ -23,21 +23,20 @@ const Register: NextPage<UserRegisterProps> = ({ email, team_id }) => {
   const formContext = useContext(FormContext);
   const { isValidate, setIsValidate } = formContext;
 
-  const [errorMessages, setErrorMessages] = useState<ErrorMessages>(InitialUserErrorMessage);
+  const router = useRouter();
 
   const handleFieldChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
 
     const validationRules = userValidationRules;
-    validationCheck({ name, value, validationRules, errorMessages, setErrorMessages });
+    const newErrorMessages = { ...errorMessages };
+    validationCheck({ name, value, validationRules, errorMessages: newErrorMessages, setErrorMessages });
 
     setUserFormData({
       ...userFormData,
       [name]: value,
     });
   };
-
-  const router = useRouter();
 
   const FormSubmit = () => {
     const options = getApiHeaders();
@@ -81,50 +80,52 @@ const Register: NextPage<UserRegisterProps> = ({ email, team_id }) => {
     });
   }, []);
 
+  const errorMessages: ErrorMessages = InitialUserErrorMessage;
+
   return (
     <>
-    <div className='flex-1'>
-      <div className='text-center text-2xl font-bold'>ユーザー登録</div>
-    </div>
-    <div className='bg-gray-50 h-full min-h-screen flex justify-center items-center'>
-      <div className='w-[768px] bg-white max-h-[80vh] overflow-auto'>
-        <UserFormGroup />
+      <div className='flex-1'>
+        <div className='text-center text-2xl font-bold'>ユーザー登録</div>
+      </div>
+      <div className='bg-gray-50 h-full min-h-screen flex justify-center items-center'>
+        <div className='w-[768px] bg-white max-h-[80vh] overflow-auto'>
+          <UserFormGroup />
 
-        <TextInput
-          name={'password'}
-          fullWidth={true}
-          multiline={false}
-          minRows={1}
-          required={true}
-          requiredMessage={'必須入力'}
-          label={'パスワード'}
-          placeholder={'Password123'}
-          type='password'
-          onChange={handleFieldChange}
-          value={userFormData.password}
-        />
-        <ErrorMessage errorMessages={errorMessages} errorKey={'password'} />
+          <TextInput
+            name={'password'}
+            fullWidth={true}
+            multiline={false}
+            minRows={1}
+            required={true}
+            requiredMessage={'必須入力'}
+            label={'パスワード'}
+            placeholder={'Password123'}
+            type='password'
+            onChange={handleFieldChange}
+            value={userFormData.password}
+          />
+          <ErrorMessage errorMessages={errorMessages} errorKey={'password'} />
 
-        <TextInput
-          name={'password_confirmation'}
-          fullWidth={true}
-          multiline={false}
-          minRows={1}
-          required={true}
-          requiredMessage={'必須入力'}
-          label={'パスワード（確認）'}
-          placeholder={'password'}
-          type='Password123'
-          onChange={handleFieldChange}
-          value={userFormData.password_confirmation}
-        />
-        <ErrorMessage errorMessages={errorMessages} errorKey={'password_confirmation'} />
+          <TextInput
+            name={'password_confirmation'}
+            fullWidth={true}
+            multiline={false}
+            minRows={1}
+            required={true}
+            requiredMessage={'必須入力'}
+            label={'パスワード（確認）'}
+            placeholder={'password'}
+            type='Password123'
+            onChange={handleFieldChange}
+            value={userFormData.password_confirmation}
+          />
+          <ErrorMessage errorMessages={errorMessages} errorKey={'password_confirmation'} />
 
-        <div className='flex justify-center pt-6'>
-          <FormSubmitButton onClick={FormSubmit} disabled={isValidate} label={'登録する'} />
+          <div className='flex justify-center pt-6'>
+            <FormSubmitButton onClick={FormSubmit} disabled={isValidate} label={'登録する'} />
+          </div>
         </div>
       </div>
-    </div>
     </>
   );
 };


### PR DESCRIPTION
## Epic


## PBI
[ローカル開発時のコンパイルが遅すぎる問題の解消](https://app.asana.com/0/1204548322306328/1206030896357397/f)

## 対象画面キャプチャ


## 実行するコマンド


## やったこと
- 無駄なレンダリングを減らして初回画面表示時間を短縮した
  - 3分15秒〜30秒程度かかっていたが、2分15秒くらいまで短縮できた。

## このPRでやらないこと
- FormModalらへん（molecules/配下）は重いと思うけど、パフォーマンス最適化だけでなく、構造的なリファクタリングが必要なため、今回はスキップした。

## 動作確認
- [ ] 確認済み

## その他
- 