### PR TITLE
無駄なレンダリングを減らして初回画面表示時間を短縮した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,8 @@ down:
 ps:
 	docker-compose ps
 
-make check:
+check:
 	npm run format && npm run lint && npm run build
+
+docker-reset:
+	docker volume prune && docker builder prune && docker container prune && docker image prune && docker network prune && docker system prune

--- a/components/organisms/Header.tsx
+++ b/components/organisms/Header.tsx
@@ -12,14 +12,9 @@ import AddIcon from '@mui/icons-material/Add';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 
 const Header: FC = () => {
-  const appContext = useContext(AppContext);
-  const { handleDrawerAreaToggle, handleMenuOpen } = appContext;
-
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
-
-  const formContext = useContext(FormContext);
-  const { setFormOpen, setFormType } = formContext;
+  const { handleDrawerAreaToggle, handleMenuOpen } = useContext(AppContext);
+  const { sessionUser } = useContext(SessionContext);
+  const { setFormOpen, setFormType } = useContext(FormContext);
 
   const handleFormOpen = (formType: FormType) => {
     setFormOpen(true);

--- a/components/organisms/Layout.tsx
+++ b/components/organisms/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect } from 'react';
+import React, { FC, useContext, useEffect, useMemo } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import { LayoutProps } from '@/types/utils';
@@ -12,15 +12,12 @@ import { getApiHeaders } from '@/utiliry/api';
 const Layout: FC<LayoutProps> = ({ children }) => {
   const router = useRouter();
 
-  const appContext = useContext(AppContext);
-  const { drawerArea } = appContext;
+  const { drawerArea } = useContext(AppContext);
+  const { setSessionUser, sessionUser, setIsAdmin, isAdmin } = useContext(SessionContext);
 
-  const sessionContext = useContext(SessionContext);
-  const { setSessionUser, sessionUser, setIsAdmin, isAdmin } = sessionContext;
-
-  const mainStyle: React.CSSProperties = {
+  const mainStyle: React.CSSProperties = useMemo(() => ({
     width: drawerArea ? 'calc(100% - 240px)' : '100%',
-  };
+  }), [drawerArea]);
 
   useEffect((): void => {
     const sessionData = getSession();

--- a/components/organisms/Layout.tsx
+++ b/components/organisms/Layout.tsx
@@ -15,9 +15,12 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   const { drawerArea } = useContext(AppContext);
   const { setSessionUser, sessionUser, setIsAdmin, isAdmin } = useContext(SessionContext);
 
-  const mainStyle: React.CSSProperties = useMemo(() => ({
-    width: drawerArea ? 'calc(100% - 240px)' : '100%',
-  }), [drawerArea]);
+  const mainStyle: React.CSSProperties = useMemo(
+    () => ({
+      width: drawerArea ? 'calc(100% - 240px)' : '100%',
+    }),
+    [drawerArea],
+  );
 
   useEffect((): void => {
     const sessionData = getSession();

--- a/components/organisms/Sidebar.tsx
+++ b/components/organisms/Sidebar.tsx
@@ -17,47 +17,24 @@ import CastForEducationIcon from '@mui/icons-material/CastForEducation';
 import TeamList from '../molecules/TeamList';
 import OutputIcon from '@mui/icons-material/Output';
 
-const Sidebar: FC = () => {
-  const appContext = useContext(AppContext);
-  const { drawerArea, handleDrawerAreaToggle } = appContext;
+const ACTIVE_STYLE = {
+  backgroundColor: '#222222',
+};
+const SX = {
+  color: '#DDDDDD',
+  mr: 1
+};
+const FONT_SIZE = 'small';
 
-  const sidebarMenus: sidebarMenus[] = [
-    {
-      id: 'dashboard',
-      label: 'ダッシュボード',
-      value: '/',
-      icon: <DashboardIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'timeline',
-      label: 'タイムライン',
-      value: '/timeline',
-      icon: <FeedIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'mypage',
-      label: 'マイページ',
-      value: '/mypage',
-      icon: <AccountCircleIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'portfolio',
-      label: 'ポートフォリオ',
-      value: '/portfolio',
-      icon: <CastForEducationIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'message',
-      label: 'メッセージ',
-      value: '/message',
-      icon: <MessageIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
-    {
-      id: 'outputs',
-      label: 'アウトプット',
-      value: '/outputs',
-      icon: <OutputIcon sx={{ color: '#DDDDDD', mr: 1 }} fontSize='small' />,
-    },
+const Sidebar: FC = () => {
+  const { drawerArea } = useContext(AppContext);
+  const menuItems = [
+    { id: 'dashboard', label: 'ダッシュボード', value: '/', icon: <DashboardIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'timeline', label: 'タイムライン', value: '/timeline', icon: <FeedIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'mypage', label: 'マイページ', value: '/mypage', icon: <AccountCircleIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'portfolio', label: 'ポートフォリオ', value: '/portfolio', icon: <CastForEducationIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'message', label: 'メッセージ', value: '/message', icon: <MessageIcon sx={SX} fontSize={FONT_SIZE} /> },
+    { id: 'outputs', label: 'アウトプット', value: '/outputs', icon: <OutputIcon sx={SX} fontSize={FONT_SIZE} /> }
   ];
   const router = useRouter();
   const isActive = (path: string) => router.pathname === path;
@@ -76,22 +53,18 @@ const Sidebar: FC = () => {
         anchor='left'
         open={drawerArea}
       >
-        <div className='bg-gray-700 h-full'>
-          <List>
-            {sidebarMenus.map((menu) => (
-              <ListItem key={menu.id} disablePadding sx={isActive(menu.value) ? { backgroundColor: '#222222' } : {}}>
-                <ListItemButton>
-                  {menu.icon}
-                  <Link href={menu.value} className='text-sm text-gray-200'>
-                    {menu.label}
-                  </Link>
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
+        <List className='bg-gray-700 h-full'>
+          {menuItems.map((menu) => (
+            <ListItem key={menu.id} disablePadding sx={isActive(menu.value) ? ACTIVE_STYLE : {}}>
+              <ListItemButton onClick={() => router.push(menu.value)}>
+                {menu.icon}
+                <span className='text-sm text-gray-200'>{menu.label}</span>
+              </ListItemButton>
+            </ListItem>
+          ))}
           <Divider className='bg-gray-500' />
           <TeamList />
-        </div>
+        </List>
       </Drawer>
     </aside>
   );

--- a/components/organisms/Sidebar.tsx
+++ b/components/organisms/Sidebar.tsx
@@ -22,7 +22,7 @@ const ACTIVE_STYLE = {
 };
 const SX = {
   color: '#DDDDDD',
-  mr: 1
+  mr: 1,
 };
 const FONT_SIZE = 'small';
 
@@ -32,9 +32,14 @@ const Sidebar: FC = () => {
     { id: 'dashboard', label: 'ダッシュボード', value: '/', icon: <DashboardIcon sx={SX} fontSize={FONT_SIZE} /> },
     { id: 'timeline', label: 'タイムライン', value: '/timeline', icon: <FeedIcon sx={SX} fontSize={FONT_SIZE} /> },
     { id: 'mypage', label: 'マイページ', value: '/mypage', icon: <AccountCircleIcon sx={SX} fontSize={FONT_SIZE} /> },
-    { id: 'portfolio', label: 'ポートフォリオ', value: '/portfolio', icon: <CastForEducationIcon sx={SX} fontSize={FONT_SIZE} /> },
+    {
+      id: 'portfolio',
+      label: 'ポートフォリオ',
+      value: '/portfolio',
+      icon: <CastForEducationIcon sx={SX} fontSize={FONT_SIZE} />,
+    },
     { id: 'message', label: 'メッセージ', value: '/message', icon: <MessageIcon sx={SX} fontSize={FONT_SIZE} /> },
-    { id: 'outputs', label: 'アウトプット', value: '/outputs', icon: <OutputIcon sx={SX} fontSize={FONT_SIZE} /> }
+    { id: 'outputs', label: 'アウトプット', value: '/outputs', icon: <OutputIcon sx={SX} fontSize={FONT_SIZE} /> },
   ];
   const router = useRouter();
   const isActive = (path: string) => router.pathname === path;

--- a/components/organisms/Sidebar.tsx
+++ b/components/organisms/Sidebar.tsx
@@ -56,9 +56,11 @@ const Sidebar: FC = () => {
         <List className='bg-gray-700 h-full'>
           {menuItems.map((menu) => (
             <ListItem key={menu.id} disablePadding sx={isActive(menu.value) ? ACTIVE_STYLE : {}}>
-              <ListItemButton onClick={() => router.push(menu.value)}>
+              <ListItemButton>
                 {menu.icon}
-                <span className='text-sm text-gray-200'>{menu.label}</span>
+                <Link href={menu.value} className='text-sm text-gray-200'>
+                  {menu.label}
+                </Link>
               </ListItemButton>
             </ListItem>
           ))}

--- a/components/templates/DashboardWrapper.tsx
+++ b/components/templates/DashboardWrapper.tsx
@@ -1,11 +1,11 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState, useMemo } from 'react';
 import Chart from '@/components/uikit/Chart';
 import RankTable from '@/components/uikit/RankTable';
 import { StackProps } from '@/types/stack';
 import axios from 'axios';
 import { getApiHeadersWithUserId } from '@/utiliry/api';
 
-const DashboardWrapper: FC = () => {
+const DashboardWrapper: FC = React.memo(() => {
   const [stacks, setStacks] = useState<StackProps[]>([]);
   const [barData, setBarData] = useState<number[]>([]);
   const [pieData, setPieData] = useState<number[]>([]);
@@ -16,18 +16,17 @@ const DashboardWrapper: FC = () => {
   const currentMonth = currentDate.getMonth() + 1;
   const daysInMonth = currentDate.getDate();
 
-  const generateLabels = (daysInMonth: number): string[] => {
+  const barLabels = useMemo(() => {
     const stackLabels: string[] = [];
     for (let i = 1; i <= daysInMonth; i++) {
       stackLabels.push(i.toString());
     }
     return stackLabels;
-  };
-
-  const barLabels = generateLabels(daysInMonth);
+  }, [daysInMonth]);
 
   useEffect(() => {
     const options = getApiHeadersWithUserId();
+
     axios
       .get(`${process.env.API_ROOT_URL}/api/v1/stacks`, options)
       .then((response) => {
@@ -122,6 +121,8 @@ const DashboardWrapper: FC = () => {
       </div>
     </div>
   );
-};
+});
+
+DashboardWrapper.displayName = 'DashboardWrapper';
 
 export default DashboardWrapper;

--- a/components/templates/OutputsWrapper.tsx
+++ b/components/templates/OutputsWrapper.tsx
@@ -4,8 +4,7 @@ import OutputCard from '../molecules/OutputCard';
 import { OutputProps, OutputsProps } from '@/types/output';
 
 const OutputsWrapper: FC<OutputsProps> = ({ outputs }) => {
-  const formContext = useContext(FormContext);
-  const { setFormOpen, setFormType } = formContext;
+  const { setFormOpen, setFormType } = useContext(FormContext);
 
   const handleFormOpen = () => {
     setFormType('createOutput');
@@ -21,7 +20,7 @@ const OutputsWrapper: FC<OutputsProps> = ({ outputs }) => {
         アウトプット追加
       </button>
       <div className='flex justify-between flex-wrap mt-8'>
-        {outputs ? (
+        {outputs && outputs.length > 0 ? (
           outputs.map((output: OutputProps) => <OutputCard key={output.id} output={output} />)
         ) : (
           <p>アウトプットがありません。</p>

--- a/components/uikit/Chart.tsx
+++ b/components/uikit/Chart.tsx
@@ -62,7 +62,7 @@ const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth,
     };
 
     return chartData;
-  }, [labels, data, bdColor, bgColor, bdwidth]);
+  }, [labels, data]);
 
   const getChartOptions = useMemo(() => {
     const chartOptions = (pattern: string) => {
@@ -155,7 +155,7 @@ const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth,
     }
 
     return chartOptions;
-  }, [data, text, pattern]);
+  }, [data]);
 
   useEffect(() => {
     const formattedChartData = getChartData();

--- a/components/uikit/Chart.tsx
+++ b/components/uikit/Chart.tsx
@@ -152,7 +152,7 @@ const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth,
         };
         return chartOptions;
       }
-    }
+    };
 
     return chartOptions;
   }, [data]);

--- a/components/uikit/Chart.tsx
+++ b/components/uikit/Chart.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, useState, useEffect, useMemo } from 'react';
 import { ChartProps, ChartData, ChartOption } from '@/types/utils';
 import { Bar, Pie } from 'react-chartjs-2';
 import Annotation from 'chartjs-plugin-annotation';
@@ -44,111 +44,118 @@ const Chart: FC<ChartProps> = ({ labels, label, data, bdColor, bgColor, bdwidth,
     if (minutes > 600000) return 'レジェンド';
   };
 
-  const getChartData = () => {
-    const chartData: ChartData = {
-      labels: labels,
-      datasets: [
-        {
-          label: label,
-          data: data,
-          borderColor: bdColor,
-          backgroundColor: bgColor,
-          borderWidth: bdwidth,
-        },
-      ],
+  const getChartData = useMemo(() => {
+    const chartData = () => {
+      const chartData: ChartData = {
+        labels: labels,
+        datasets: [
+          {
+            label: label,
+            data: data,
+            backgroundColor: bgColor,
+            borderColor: bdColor,
+            borderWidth: bdwidth,
+          },
+        ],
+      };
+      return chartData;
     };
 
     return chartData;
-  };
+  }, [labels, data, bdColor, bgColor, bdwidth]);
 
-  const getChartOptions = (pattern: string) => {
-    if (pattern === 'SkillRankGraph') {
-      const maxDataValue = Math.max(...data);
-      const scaledMax = maxDataValue * 1.2;
+  const getChartOptions = useMemo(() => {
+    const chartOptions = (pattern: string) => {
+      if (pattern === 'SkillRankGraph') {
+        const maxDataValue = Math.max(...data);
+        const scaledMax = maxDataValue * 1.2;
 
-      const chartOptions: ChartOption = {
-        responsive: true,
-        plugins: {
-          title: {
-            display: true,
-            text: text,
-          },
-          tooltip: {
-            callbacks: {
-              label: function (context) {
-                const minutes = context.parsed.y;
-                const rank = RankingIndex(minutes);
-                return `時間: ${minutes}  ランク: ${rank}`;
+        const chartOptions: ChartOption = {
+          responsive: true,
+          plugins: {
+            title: {
+              display: true,
+              text: text,
+            },
+            tooltip: {
+              callbacks: {
+                label: function (context) {
+                  const minutes = context.parsed.y;
+                  const rank = RankingIndex(minutes);
+                  return `時間: ${minutes}  ランク: ${rank}`;
+                },
+              },
+            },
+            annotation: {
+              annotations: {
+                legendLine: {
+                  type: 'line',
+                  yMin: 600000,
+                  yMax: 600000,
+                  borderColor: 'rgba(224, 17, 95, 0.5)',
+                  borderWidth: 2,
+                },
+                masterLine: {
+                  type: 'line',
+                  yMin: 300000,
+                  yMax: 300000,
+                  borderColor: 'rgba(75, 0, 130, 0.5)',
+                  borderWidth: 2,
+                },
+                diamondLine: {
+                  type: 'line',
+                  yMin: 100000,
+                  yMax: 100000,
+                  borderColor: 'rgba(173, 216, 230, 0.5)',
+                  borderWidth: 2,
+                },
+                platinumLine: {
+                  type: 'line',
+                  yMin: 60000,
+                  yMax: 60000,
+                  borderColor: 'rgba(192, 192, 224, 0.5)',
+                  borderWidth: 2,
+                },
+                goldLine: {
+                  type: 'line',
+                  yMin: 30000,
+                  yMax: 30000,
+                  borderColor: 'rgba(255, 215, 0, 0.5)',
+                  borderWidth: 2,
+                },
+                silverLine: {
+                  type: 'line',
+                  yMin: 10000,
+                  yMax: 10000,
+                  borderColor: 'rgba(192, 192, 192, 0.5)',
+                  borderWidth: 2,
+                },
               },
             },
           },
-          annotation: {
-            annotations: {
-              legendLine: {
-                type: 'line',
-                yMin: 600000,
-                yMax: 600000,
-                borderColor: 'rgba(224, 17, 95, 0.5)',
-                borderWidth: 2,
-              },
-              masterLine: {
-                type: 'line',
-                yMin: 300000,
-                yMax: 300000,
-                borderColor: 'rgba(75, 0, 130, 0.5)',
-                borderWidth: 2,
-              },
-              diamondLine: {
-                type: 'line',
-                yMin: 100000,
-                yMax: 100000,
-                borderColor: 'rgba(173, 216, 230, 0.5)',
-                borderWidth: 2,
-              },
-              platinumLine: {
-                type: 'line',
-                yMin: 60000,
-                yMax: 60000,
-                borderColor: 'rgba(192, 192, 224, 0.5)',
-                borderWidth: 2,
-              },
-              goldLine: {
-                type: 'line',
-                yMin: 30000,
-                yMax: 30000,
-                borderColor: 'rgba(255, 215, 0, 0.5)',
-                borderWidth: 2,
-              },
-              silverLine: {
-                type: 'line',
-                yMin: 10000,
-                yMax: 10000,
-                borderColor: 'rgba(192, 192, 192, 0.5)',
-                borderWidth: 2,
-              },
+          scales: {
+            y: {
+              suggestedMax: scaledMax,
             },
           },
-        },
-        scales: {
-          y: {
-            suggestedMax: scaledMax,
+        };
+        return chartOptions;
+      } else {
+        const chartOptions: ChartOption = {
+          responsive: true,
+          plugins: {
+            title: {
+              display: true,
+              text: text,
+            },
           },
-        },
-      };
-      return chartOptions;
-    } else {
-      const chartOptions: ChartOption = {
-        responsive: true,
-        plugins: {
-          title: {
-            display: true,
-            text: text,
-          },
-        },
-      };
-      return chartOptions;
+        };
+        return chartOptions;
+      }
     }
-  };
+
+    return chartOptions;
+  }, [data, text, pattern]);
 
   useEffect(() => {
     const formattedChartData = getChartData();

--- a/components/uikit/HeaderMenu.tsx
+++ b/components/uikit/HeaderMenu.tsx
@@ -9,17 +9,19 @@ import { AppContext } from '@/context/AppContext';
 import { SessionContext } from '@/context/SessionContext';
 import axios from 'axios';
 
+interface MenuItemInfo {
+  icon: React.ReactNode;
+  text: string;
+  action: () => void;
+}
+
 const HeaderMenu: FC = () => {
-  const appContext = useContext(AppContext);
-  const { anchorEl, handleMenuClose } = appContext;
+  const { anchorEl, handleMenuClose } = useContext(AppContext);
+  const { setSessionUser } = useContext(SessionContext);
 
-  const sessionContext = useContext(SessionContext);
-  const { setSessionUser } = sessionContext;
-
-  const open = Boolean(anchorEl);
   const router = useRouter();
 
-  const LogoutUser = async () => {
+  const logoutUser = async () => {
     try {
       await axios.post('/api/logout');
       localStorage.removeItem('session');
@@ -31,11 +33,24 @@ const HeaderMenu: FC = () => {
     }
   };
 
+  const menuItems: MenuItemInfo[] = [
+    {
+      icon: <Settings fontSize='small' />,
+      text: '設定',
+      action: handleMenuClose,
+    },
+    {
+      icon: <Logout fontSize='small' />,
+      text: 'ログアウト',
+      action: logoutUser,
+    },
+  ];
+
   return (
     <div>
       <Menu
         anchorEl={anchorEl}
-        open={open}
+        open={Boolean(anchorEl)}
         onClose={handleMenuClose}
         onClick={handleMenuClose}
         PaperProps={{
@@ -67,21 +82,15 @@ const HeaderMenu: FC = () => {
         transformOrigin={{ horizontal: 'right', vertical: 'top' }}
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
-        <MenuItem onClick={handleMenuClose}>
-          <ListItemIcon>
-            <Settings fontSize='small' />
-          </ListItemIcon>
-          設定
-        </MenuItem>
-        <MenuItem onClick={handleMenuClose}>
-          <ListItemIcon>
-            <Logout fontSize='small' />
-          </ListItemIcon>
-          <div onClick={LogoutUser}>ログアウト</div>
-        </MenuItem>
+        {menuItems.map((item, index) => (
+          <MenuItem key={index} onClick={item.action}>
+            <ListItemIcon>{item.icon}</ListItemIcon>
+            {item.text}
+          </MenuItem>
+        ))}
       </Menu>
     </div>
   );
 };
 
-export default HeaderMenu;
+export default React.memo(HeaderMenu);

--- a/components/uikit/RankTable.tsx
+++ b/components/uikit/RankTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useState } from 'react';
+import React, { FC, useContext, useEffect, useMemo, useState, useCallback } from 'react';
 
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -7,6 +7,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
+
 import { getApiHeaders } from '@/utiliry/api';
 import { SessionContext } from '@/context/SessionContext';
 import { callFetchStackRankings } from '@/utiliry/api/stack-ranking';
@@ -25,8 +26,7 @@ const RankTable: FC = () => {
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(10);
 
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
+  const { sessionUser } =  useContext(SessionContext);
 
   const [stackRankings, setStackRankings] = useState<StackRankings[]>([]);
 
@@ -35,19 +35,30 @@ const RankTable: FC = () => {
     { id: 'user_name', label: 'ユーザー名' },
   ];
 
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handleChangePage = useCallback((_event: unknown, newPage: number) => {
     setPage(newPage);
-  };
+  }, []);
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeRowsPerPage = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(+event.target.value);
     setPage(0);
-  };
+  }, []);
 
   useEffect(() => {
     const options = getApiHeaders();
     callFetchStackRankings({ options, sessionUser, setStackRankings });
   }, [sessionUser]);
+
+  const paginatedData = useMemo(() => {
+    if (!stackRankings) {
+      return [];
+    }
+
+    const startIndex = page * rowsPerPage;
+    const endIndex = startIndex + rowsPerPage;
+
+    return stackRankings.slice(startIndex, endIndex);
+  }, [page, rowsPerPage, stackRankings]);
 
   return (
     <>
@@ -63,16 +74,13 @@ const RankTable: FC = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {stackRankings.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((row) => {
-              return (
-                <TableRow hover role='checkbox' tabIndex={-1} key={row.order}>
-                  {StackRankingColumns.map((column) => {
-                    const value = row[column.id];
-                    return <TableCell key={column.id}>{value}</TableCell>;
-                  })}
-                </TableRow>
-              );
-            })}
+            {paginatedData.map((row) => (
+              <TableRow hover role='checkbox' tabIndex={-1} key={row.order}>
+                {StackRankingColumns.map((column) => (
+                  <TableCell key={column.id}>{row[column.id]}</TableCell>
+                ))}
+              </TableRow>
+            ))}
           </TableBody>
         </Table>
       </TableContainer>

--- a/components/uikit/RankTable.tsx
+++ b/components/uikit/RankTable.tsx
@@ -26,7 +26,7 @@ const RankTable: FC = () => {
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(10);
 
-  const { sessionUser } =  useContext(SessionContext);
+  const { sessionUser } = useContext(SessionContext);
 
   const [stackRankings, setStackRankings] = useState<StackRankings[]>([]);
 

--- a/components/uikit/RankTable.tsx
+++ b/components/uikit/RankTable.tsx
@@ -55,7 +55,7 @@ const RankTable: FC = () => {
     }
 
     const startIndex = page * rowsPerPage;
-    const endIndex = startIndex + rowsPerPage;
+    const endIndex = page * startIndex + rowsPerPage;
 
     return stackRankings.slice(startIndex, endIndex);
   }, [page, rowsPerPage, stackRankings]);

--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, createContext, useState } from 'react';
+import React, { MouseEvent, createContext, useState, useCallback, useMemo } from 'react';
 import { ChildrenProps } from '@/types/utils';
 import { AppContextProps } from '@/types/context';
 
@@ -16,30 +16,30 @@ const AppContext = createContext<AppContextProps>(InitialState);
 
 const AppProvider = ({ children }: ChildrenProps) => {
   const [drawerArea, setDrawerArea] = useState<boolean>(true);
-  const handleDrawerAreaToggle: () => void = () => {
-    setDrawerArea(!drawerArea);
-  };
-
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const handleMenuOpen = (event: MouseEvent<HTMLElement>) => {
+
+  const handleDrawerAreaToggle = useCallback(() => {
+    setDrawerArea(!drawerArea);
+  }, []);
+  const handleMenuOpen = useCallback((event: MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
-  };
-  const handleMenuClose: () => void = () => {
+  }, []);
+  const handleMenuClose = useCallback(() => {
     setAnchorEl(null);
-  };
+  }, []);
+
+  const providerValue = useMemo(() => ({
+    drawerArea,
+    setDrawerArea,
+    handleDrawerAreaToggle,
+    anchorEl,
+    setAnchorEl,
+    handleMenuOpen,
+    handleMenuClose,
+  }), [drawerArea, anchorEl]);
 
   return (
-    <AppContext.Provider
-      value={{
-        drawerArea: drawerArea,
-        setDrawerArea: setDrawerArea,
-        handleDrawerAreaToggle: handleDrawerAreaToggle,
-        anchorEl: anchorEl,
-        setAnchorEl: setAnchorEl,
-        handleMenuOpen: handleMenuOpen,
-        handleMenuClose: handleMenuClose,
-      }}
-    >
+    <AppContext.Provider value={providerValue}>
       {children}
     </AppContext.Provider>
   );

--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -28,21 +28,20 @@ const AppProvider = ({ children }: ChildrenProps) => {
     setAnchorEl(null);
   }, []);
 
-  const providerValue = useMemo(() => ({
-    drawerArea,
-    setDrawerArea,
-    handleDrawerAreaToggle,
-    anchorEl,
-    setAnchorEl,
-    handleMenuOpen,
-    handleMenuClose,
-  }), [drawerArea, anchorEl]);
-
-  return (
-    <AppContext.Provider value={providerValue}>
-      {children}
-    </AppContext.Provider>
+  const providerValue = useMemo(
+    () => ({
+      drawerArea,
+      setDrawerArea,
+      handleDrawerAreaToggle,
+      anchorEl,
+      setAnchorEl,
+      handleMenuOpen,
+      handleMenuClose,
+    }),
+    [drawerArea, anchorEl],
   );
+
+  return <AppContext.Provider value={providerValue}>{children}</AppContext.Provider>;
 };
 
 export { AppProvider, AppContext };

--- a/context/FormContext.tsx
+++ b/context/FormContext.tsx
@@ -22,22 +22,21 @@ const FormProvider = ({ children }: ChildrenProps) => {
   const [isRegisterEvent, setIsRegisterEvent] = useState<boolean>(false);
   const [isValidate, setIsValidate] = useState<boolean>(true);
 
-  const providerValue = useMemo(() => ({
-    formType,
-    setFormType,
-    formOpen,
-    setFormOpen,
-    isRegisterEvent,
-    setIsRegisterEvent,
-    isValidate,
-    setIsValidate,
-  }), [formType, formOpen, isRegisterEvent, isValidate]);
-
-  return (
-    <FormContext.Provider value={providerValue}>
-      {children}
-    </FormContext.Provider>
+  const providerValue = useMemo(
+    () => ({
+      formType,
+      setFormType,
+      formOpen,
+      setFormOpen,
+      isRegisterEvent,
+      setIsRegisterEvent,
+      isValidate,
+      setIsValidate,
+    }),
+    [formType, formOpen, isRegisterEvent, isValidate],
   );
+
+  return <FormContext.Provider value={providerValue}>{children}</FormContext.Provider>;
 };
 
 export { FormProvider, FormContext };

--- a/context/FormContext.tsx
+++ b/context/FormContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useMemo } from 'react';
 import { ChildrenProps } from '@/types/utils';
 import { FormType } from '@/types/form';
 import { FormContextProps } from '@/types/context';
@@ -22,19 +22,19 @@ const FormProvider = ({ children }: ChildrenProps) => {
   const [isRegisterEvent, setIsRegisterEvent] = useState<boolean>(false);
   const [isValidate, setIsValidate] = useState<boolean>(true);
 
+  const providerValue = useMemo(() => ({
+    formType,
+    setFormType,
+    formOpen,
+    setFormOpen,
+    isRegisterEvent,
+    setIsRegisterEvent,
+    isValidate,
+    setIsValidate,
+  }), [formType, formOpen, isRegisterEvent, isValidate]);
+
   return (
-    <FormContext.Provider
-      value={{
-        formType: formType,
-        setFormType: setFormType,
-        formOpen: formOpen,
-        setFormOpen: setFormOpen,
-        isRegisterEvent: isRegisterEvent,
-        setIsRegisterEvent: setIsRegisterEvent,
-        isValidate: isValidate,
-        setIsValidate: setIsValidate,
-      }}
-    >
+    <FormContext.Provider value={providerValue}>
       {children}
     </FormContext.Provider>
   );

--- a/context/FormDataContext.tsx
+++ b/context/FormDataContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useMemo } from 'react';
 import { ChildrenProps } from '@/types/utils';
 import { IntrospectionProps } from '@/types/introspection';
 import {
@@ -54,27 +54,27 @@ const FormDataProvider = ({ children }: ChildrenProps) => {
   const [outputCommentFormData, setOutputCommentFormData] =
     useState<OutputCommentFormDataParams>(InitialOutputCommentFormData);
 
+  const providerValue = useMemo(() => ({
+    teamFormData,
+    setTeamFormData,
+    inviteTeamFormData,
+    setInviteTeamFormData,
+    userFormData,
+    setUserFormData,
+    stackFormData,
+    setStackFormData,
+    introspectionFormData,
+    setIntrospectionFormData,
+    showStackIntrospection,
+    setShowStackIntrospection,
+    outputFormData,
+    setOutputFormData,
+    outputCommentFormData,
+    setOutputCommentFormData,
+  }), [teamFormData, inviteTeamFormData, userFormData, stackFormData, introspectionFormData, showStackIntrospection, outputFormData, outputCommentFormData]);
+
   return (
-    <FormDataContext.Provider
-      value={{
-        teamFormData: teamFormData,
-        setTeamFormData: setTeamFormData,
-        inviteTeamFormData: inviteTeamFormData,
-        setInviteTeamFormData: setInviteTeamFormData,
-        userFormData: userFormData,
-        setUserFormData: setUserFormData,
-        stackFormData: stackFormData,
-        setStackFormData: setStackFormData,
-        introspectionFormData: introspectionFormData,
-        setIntrospectionFormData: setIntrospectionFormData,
-        showStackIntrospection: showStackIntrospection,
-        setShowStackIntrospection: setShowStackIntrospection,
-        outputFormData: outputFormData,
-        setOutputFormData: setOutputFormData,
-        outputCommentFormData: outputCommentFormData,
-        setOutputCommentFormData: setOutputCommentFormData,
-      }}
-    >
+    <FormDataContext.Provider value={providerValue}>
       {children}
     </FormDataContext.Provider>
   );

--- a/context/FormDataContext.tsx
+++ b/context/FormDataContext.tsx
@@ -54,30 +54,38 @@ const FormDataProvider = ({ children }: ChildrenProps) => {
   const [outputCommentFormData, setOutputCommentFormData] =
     useState<OutputCommentFormDataParams>(InitialOutputCommentFormData);
 
-  const providerValue = useMemo(() => ({
-    teamFormData,
-    setTeamFormData,
-    inviteTeamFormData,
-    setInviteTeamFormData,
-    userFormData,
-    setUserFormData,
-    stackFormData,
-    setStackFormData,
-    introspectionFormData,
-    setIntrospectionFormData,
-    showStackIntrospection,
-    setShowStackIntrospection,
-    outputFormData,
-    setOutputFormData,
-    outputCommentFormData,
-    setOutputCommentFormData,
-  }), [teamFormData, inviteTeamFormData, userFormData, stackFormData, introspectionFormData, showStackIntrospection, outputFormData, outputCommentFormData]);
-
-  return (
-    <FormDataContext.Provider value={providerValue}>
-      {children}
-    </FormDataContext.Provider>
+  const providerValue = useMemo(
+    () => ({
+      teamFormData,
+      setTeamFormData,
+      inviteTeamFormData,
+      setInviteTeamFormData,
+      userFormData,
+      setUserFormData,
+      stackFormData,
+      setStackFormData,
+      introspectionFormData,
+      setIntrospectionFormData,
+      showStackIntrospection,
+      setShowStackIntrospection,
+      outputFormData,
+      setOutputFormData,
+      outputCommentFormData,
+      setOutputCommentFormData,
+    }),
+    [
+      teamFormData,
+      inviteTeamFormData,
+      userFormData,
+      stackFormData,
+      introspectionFormData,
+      showStackIntrospection,
+      outputFormData,
+      outputCommentFormData,
+    ],
   );
+
+  return <FormDataContext.Provider value={providerValue}>{children}</FormDataContext.Provider>;
 };
 
 export { FormDataProvider, FormDataContext };

--- a/context/SessionContext.tsx
+++ b/context/SessionContext.tsx
@@ -16,18 +16,17 @@ const SessionProvider = ({ children }: ChildrenProps) => {
   const [sessionUser, setSessionUser] = useState<sessionUser>(undefined);
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
-  const providerValue = useMemo(() => ({
-    sessionUser,
-    setSessionUser,
-    isAdmin,
-    setIsAdmin,
-  }), [sessionUser, isAdmin]);
-
-  return (
-    <SessionContext.Provider value={providerValue}>
-      {children}
-    </SessionContext.Provider>
+  const providerValue = useMemo(
+    () => ({
+      sessionUser,
+      setSessionUser,
+      isAdmin,
+      setIsAdmin,
+    }),
+    [sessionUser, isAdmin],
   );
+
+  return <SessionContext.Provider value={providerValue}>{children}</SessionContext.Provider>;
 };
 
 export { SessionProvider, SessionContext };

--- a/context/SessionContext.tsx
+++ b/context/SessionContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useMemo } from 'react';
 import { ChildrenProps } from '@/types/utils';
 import { sessionUser } from '@/types/session';
 import { SessionContextProps } from '@/types/context';
@@ -16,15 +16,15 @@ const SessionProvider = ({ children }: ChildrenProps) => {
   const [sessionUser, setSessionUser] = useState<sessionUser>(undefined);
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
+  const providerValue = useMemo(() => ({
+    sessionUser,
+    setSessionUser,
+    isAdmin,
+    setIsAdmin,
+  }), [sessionUser, isAdmin]);
+
   return (
-    <SessionContext.Provider
-      value={{
-        sessionUser: sessionUser,
-        setSessionUser: setSessionUser,
-        isAdmin: isAdmin,
-        setIsAdmin: setIsAdmin,
-      }}
-    >
+    <SessionContext.Provider value={providerValue}>
       {children}
     </SessionContext.Provider>
   );

--- a/context/SnackbarContext.tsx
+++ b/context/SnackbarContext.tsx
@@ -32,9 +32,7 @@ const SnackbarProvider = ({ children }: ChildrenProps) => {
 
   return (
     <>
-      <SnackbarContext.Provider value={{ showSnackbar: showSnackbar }}>
-        {children}
-      </SnackbarContext.Provider>
+      <SnackbarContext.Provider value={{ showSnackbar: showSnackbar }}>{children}</SnackbarContext.Provider>
       <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
         <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
           {message}

--- a/context/SnackbarContext.tsx
+++ b/context/SnackbarContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, FC } from 'react';
+import React, { createContext, useState, useCallback } from 'react';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import { ChildrenProps } from '@/types/utils';
@@ -16,23 +16,25 @@ const SnackbarProvider = ({ children }: ChildrenProps) => {
   const [severity, setSeverity] = useState<SnackbarSeverity>('info');
   const [message, setMessage] = useState<string>('');
 
-  const showSnackbar = (type: SnackbarSeverity, message: string): void => {
+  const showSnackbar = useCallback((type: SnackbarSeverity, message: string): void => {
     setOpen(true);
     setSeverity(type);
     setMessage(message);
-  };
+  }, []);
 
-  const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
+  const handleClose = useCallback((event: React.SyntheticEvent | Event, reason?: string) => {
     if (reason === 'clickaway') {
       return;
     }
 
     setOpen(false);
-  };
+  }, []);
 
   return (
     <>
-      <SnackbarContext.Provider value={{ showSnackbar: showSnackbar }}>{children}</SnackbarContext.Provider>
+      <SnackbarContext.Provider value={{ showSnackbar: showSnackbar }}>
+        {children}
+      </SnackbarContext.Provider>
       <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
         <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
           {message}

--- a/pages/outputs/[output].tsx
+++ b/pages/outputs/[output].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext, useCallback } from 'react';
 import axios from 'axios';
 import cookie from 'cookie';
 import { GetServerSideProps, NextPage } from 'next';
@@ -6,25 +6,24 @@ import { getNextApiHeaders } from '@/utiliry/api';
 import { useRouter } from 'next/router';
 import { OutputCardProps, CommentProps } from '@/types/output';
 import { FormContext } from '@/context/FormContext';
-import FormModal from '@/components/molecules/FormModal'
+import FormModal from '@/components/molecules/FormModal';
 import { InitialOutputCommentFormData } from '@/utiliry/form';
 import { FormDataContext } from '@/context/FormDataContext';
 
 const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
   const router = useRouter();
   const handleBack = () => router.back();
-  const [comments, setComments] = useState(initialComments);
 
-  const formContext = useContext(FormContext);
-  const { setFormOpen, setFormType } = formContext;
-  const formDataContext = useContext(FormDataContext);
-  const { setOutputCommentFormData } = formDataContext;
-  const handleFormOpen = () => {
+  const [comments, setComments] = useState(initialComments);
+  const { setFormOpen, setFormType } = useContext(FormContext);
+  const { setOutputCommentFormData } = useContext(FormDataContext);
+
+  const handleFormOpen = useCallback(() => {
     const outputId = output.id
     setOutputCommentFormData({ ...InitialOutputCommentFormData, outputId })
     setFormType('createOutputComment');
     setFormOpen(true);
-  }
+  }, []);
 
   useEffect(() => {
     setComments(initialComments);

--- a/pages/outputs/index.tsx
+++ b/pages/outputs/index.tsx
@@ -1,23 +1,23 @@
-import React from 'react'
-import axios from 'axios'
-import Layout from '@/components/organisms/Layout'
-import OutputsWrapper from '@/components/templates/OutputsWrapper'
-import { GetServerSideProps, NextPage } from 'next'
+import React from 'react';
+import axios from 'axios';
+import Layout from '@/components/organisms/Layout';
+import OutputsWrapper from '@/components/templates/OutputsWrapper';
 import cookie from 'cookie';
-import { getNextApiHeaders } from '@/utiliry/api'
-import { OutputsProps } from '@/types/output'
+import { GetServerSideProps, NextPage } from 'next';
+import { getNextApiHeaders } from '@/utiliry/api';
+import { OutputsProps } from '@/types/output';
 
-const index: NextPage<OutputsProps> = ({ outputs }) => {
+const Index: NextPage<OutputsProps> = ({ outputs }) => {
   return (
     <div>
       <Layout>
         <OutputsWrapper outputs={outputs} />
       </Layout>
     </div>
-  )
-}
+  );
+};
 
-export default index
+export default Index;
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   try {
@@ -39,4 +39,4 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     console.error('Error fetching data:', error);
     return { props: {} };
   }
-}
+};

--- a/pages/timeline/index.tsx
+++ b/pages/timeline/index.tsx
@@ -1,18 +1,17 @@
-import React, { useContext, useEffect, useState } from 'react'
-import { NextPage } from 'next'
-import Layout from '@/components/organisms/Layout'
-import StackList from '@/components/molecules/StackList'
-import { StackProps } from '@/types/stack'
-import { getSession } from '@/utiliry/session'
-import { ApiOptions } from '@/types/api'
-import { SessionContext } from '@/context/SessionContext'
-import axios from 'axios'
+import React, { useContext, useEffect, useState } from 'react';
+import { NextPage } from 'next';
+import Layout from '@/components/organisms/Layout';
+import StackList from '@/components/molecules/StackList';
+import { StackProps } from '@/types/stack';
+import { getSession } from '@/utiliry/session';
+import { ApiOptions } from '@/types/api';
+import { SessionContext } from '@/context/SessionContext';
+import axios from 'axios';
 
 const Index: NextPage = () => {
   const [stacks, setStacks] = useState<StackProps[]>([]);
-  
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext
+
+  const { sessionUser } = useContext(SessionContext);
 
   useEffect(() => {
     const sessionData = getSession();
@@ -26,7 +25,7 @@ const Index: NextPage = () => {
         },
         params: { team_id: sessionUser?.team.id }
       };
-      const url = `${process.env.API_ROOT_URL}/api/v1/stacks`
+      const url = `${process.env.API_ROOT_URL}/api/v1/stacks`;
 
       try {
         const response = await axios.get(url, options);
@@ -43,7 +42,7 @@ const Index: NextPage = () => {
     <Layout>
       <StackList stacks={stacks} />
     </Layout>
-  )
-}
+  );
+};
 
-export default Index
+export default Index;

--- a/pages/users/register.tsx
+++ b/pages/users/register.tsx
@@ -17,13 +17,11 @@ import FormSubmitButton from '@/components/atoms/FormSubmitButton';
 import UserFormGroup from '@/components/molecules/UserFormGroup';
 
 const Register: NextPage<UserRegisterProps> = ({ email, team_id }) => {
-  const formDataContext = useContext(FormDataContext);
-  const { userFormData, setUserFormData } = formDataContext;
-
-  const formContext = useContext(FormContext);
-  const { isValidate, setIsValidate } = formContext;
+  const { userFormData, setUserFormData } = useContext(FormDataContext);
+  const { isValidate, setIsValidate } = useContext(FormContext);
 
   const [errorMessages, setErrorMessages] = useState<ErrorMessages>(InitialUserErrorMessage);
+  const router = useRouter();
 
   const handleFieldChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -36,8 +34,6 @@ const Register: NextPage<UserRegisterProps> = ({ email, team_id }) => {
       [name]: value,
     });
   };
-
-  const router = useRouter();
 
   const FormSubmit = () => {
     const options = getApiHeaders();


### PR DESCRIPTION
https://github.com/mnmuu8/frontend_stack/pull/81 の改訂版

## Epic


## PBI
[ローカル開発時のコンパイルが遅すぎる問題の解消](https://app.asana.com/0/1204548322306328/1206030896357397/f)

## 対象画面キャプチャ


## 実行するコマンド


## やったこと
- 無駄なレンダリングを減らして初回画面表示時間を短縮した
  - 3分15秒〜30秒程度かかっていたが、2分15秒くらいまで短縮できた。

## このPRでやらないこと
- FormModalらへん（molecules/配下）は重いと思うけど、パフォーマンス最適化だけでなく、構造的なリファクタリングが必要なため、今回はスキップした。

## 動作確認
- [x] 確認済み

## その他
- 