### PR TITLE
アウトプット一覧と詳細ページのレイアウト変更

### DIFF
--- a/common/constans/sizes.ts
+++ b/common/constans/sizes.ts
@@ -1,0 +1,9 @@
+// ユーザーのプロフィールアイコン
+export const USER_PROFILE_HEIGHT_SM: number = 26;
+export const USER_PROFILE_WIDTH_SM: number = 26;
+
+export const USER_PROFILE_HEIGHT_MD: number = 100;
+export const USER_PROFILE_WIDTH_MD: number = 100;
+
+export const USER_PROFILE_HEIGHT_LG: number = 180;
+export const USER_PROFILE_WIDTH_LG: number = 180;

--- a/common/styles/globals.css
+++ b/common/styles/globals.css
@@ -88,8 +88,8 @@ h3 {
 }
 
 .MoreButton {
-  @apply absolute left-0 right-0 bottom-6 p-6 text-center cursor-pointer;
-  background: linear-gradient(to top, rgb(249, 250, 251), rgba(0, 0, 0, 0));
+  @apply absolute left-0 right-0 bottom-0 p-6 text-center text-sm text-white cursor-pointer;
+  background: linear-gradient(to top, rgb(0, 0, 0, 0.5), rgba(0, 0, 0, 0));
 }
 
 .ProfileImage {

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -10,6 +10,7 @@ import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import AddIcon from '@mui/icons-material/Add';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { USER_PROFILE_HEIGHT_SM, USER_PROFILE_WIDTH_SM } from '@/common/constans/sizes';
 
 const Header: FC = () => {
   const { handleDrawerAreaToggle, handleMenuOpen } = useContext(AppContext);
@@ -21,11 +22,9 @@ const Header: FC = () => {
     setFormType(formType);
   };
 
-  const USER_PROFILE_HEIGHT = 30;
-  const USER_PROFILE_WIDTH = 30;
-  const USER_PROFILE_SRC_PATH =
+  const userProfileSrcPath =
     sessionUser && sessionUser.profile_image_path !== null ? sessionUser.profile_image_path : '/no_image.png';
-  const USER_PROFILE_NAME = sessionUser && sessionUser.name !== null ? sessionUser.name : 'noname';
+  const userProfileName = sessionUser && sessionUser.name !== null ? sessionUser.name : 'noname';
 
   return (
     <header className='bg-gray-700 h-[60px] border-b-[1px] border-gray-500'>
@@ -45,10 +44,10 @@ const Header: FC = () => {
         <div className='flex items-center cursor-pointer' onClick={handleMenuOpen}>
           {sessionUser && (
             <ImageWrapper
-              src={USER_PROFILE_SRC_PATH}
-              height={USER_PROFILE_HEIGHT}
-              width={USER_PROFILE_WIDTH}
-              alt={USER_PROFILE_NAME}
+              src={userProfileSrcPath}
+              height={USER_PROFILE_HEIGHT_SM}
+              width={USER_PROFILE_WIDTH_SM}
+              alt={userProfileName}
               className='rounded-full'
             />
           )}

--- a/features/outputs/comments/components/OutputCommentCard.tsx
+++ b/features/outputs/comments/components/OutputCommentCard.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react'
+import ImageWrapper from '@/components/ui-elements/ImageWrapper';
+import { CommentProps } from '../../types/output';
+
+const OutputCommentCard: FC<{ comment: CommentProps }> = ({ comment }) => {
+  const formatTimeAgo = (dateString: string) => {
+    const date = new Date(dateString);
+    const diffInSeconds = (new Date().getTime() - date.getTime()) / 1000;
+  
+    if (diffInSeconds < 60) return 'たった今';
+  
+    return new Intl.DateTimeFormat('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit'
+    }).format(date);
+  };
+
+  const timeAgo = formatTimeAgo(comment.created_at);
+
+  // TODO: 現状は仮情報を使用しており、アウトプットのコメントにユーザー紐づけたら更新
+  const USER_PROFILE_HEIGHT = 26;
+  const USER_PROFILE_WIDTH = 26;
+  const USER_PROFILE_SRC_PATH = '/no_image.png';
+  const USER_PROFILE_NAME = 'example';
+
+  return (
+    <div className='bg-gray-50 border-b py-2 px-4'>
+      <div className='flex items-center'>
+        <ImageWrapper
+          src={USER_PROFILE_SRC_PATH}
+          height={USER_PROFILE_HEIGHT}
+          width={USER_PROFILE_WIDTH}
+          alt={USER_PROFILE_NAME}
+          className='rounded-full'
+        />
+        <div className='text-sm ml-1'>{comment.user.name}</div>
+        <div className='text-gray-400 text-[10px] ml-2'>{timeAgo}</div>
+      </div>
+      <div className='text-sm mt-2'>{comment.content}</div>
+    </div>
+  )
+}
+
+export default OutputCommentCard

--- a/features/outputs/comments/components/OutputCommentCard.tsx
+++ b/features/outputs/comments/components/OutputCommentCard.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react'
 import ImageWrapper from '@/components/ui-elements/ImageWrapper';
 import { CommentProps } from '../../types/output';
+import { USER_PROFILE_HEIGHT_SM, USER_PROFILE_WIDTH_SM } from '@/common/constans/sizes';
 
 const OutputCommentCard: FC<{ comment: CommentProps }> = ({ comment }) => {
   const formatTimeAgo = (dateString: string) => {
@@ -19,19 +20,17 @@ const OutputCommentCard: FC<{ comment: CommentProps }> = ({ comment }) => {
   const timeAgo = formatTimeAgo(comment.created_at);
 
   // TODO: 現状は仮情報を使用しており、アウトプットのコメントにユーザー紐づけたら更新
-  const USER_PROFILE_HEIGHT = 26;
-  const USER_PROFILE_WIDTH = 26;
-  const USER_PROFILE_SRC_PATH = '/no_image.png';
-  const USER_PROFILE_NAME = 'example';
+  const userProfileSrcPath = '/no_image.png';
+  const userProfileName = 'example';
 
   return (
     <div className='bg-gray-50 border-b py-2 px-4'>
       <div className='flex items-center'>
         <ImageWrapper
-          src={USER_PROFILE_SRC_PATH}
-          height={USER_PROFILE_HEIGHT}
-          width={USER_PROFILE_WIDTH}
-          alt={USER_PROFILE_NAME}
+          src={userProfileSrcPath}
+          height={USER_PROFILE_HEIGHT_SM}
+          width={USER_PROFILE_WIDTH_SM}
+          alt={userProfileName}
           className='rounded-full'
         />
         <div className='text-sm ml-1'>{comment.user.name}</div>

--- a/features/outputs/components/OutputCard.tsx
+++ b/features/outputs/components/OutputCard.tsx
@@ -1,14 +1,26 @@
 import React, { FC, useContext, useEffect, useRef, useState } from 'react';
 import { SessionContext } from '@/context/SessionContext';
-import UserProfile from '@/features/users/components/UserProfile';
 import { OutputCardProps } from '../types/output';
 import { formatDate } from '@/common/functions/dateUtils';
+import ImageWrapper from '@/components/ui-elements/ImageWrapper';
+import EditIcon from '@mui/icons-material/Edit';
 import Link from 'next/link';
 
 const OutputCard: FC<OutputCardProps> = ({ output }) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const [showMoreButton, setShowMoreButton] = useState<boolean>(false);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  const sessionContext = useContext(SessionContext);
+  const { sessionUser } = sessionContext;
+
+  const outputCreatedAt = output.created_at;
+  const formattedCreateDate = formatDate(outputCreatedAt);
+
+  const USER_PROFILE_HEIGHT = 32;
+  const USER_PROFILE_WIDTH = 32;
+  const USER_PROFILE_SRC_PATH = sessionUser && sessionUser.profile_image_path !== null ? sessionUser.profile_image_path : '/no_image.png';
+  const USER_PROFILE_NAME = sessionUser && sessionUser.name !== null ? sessionUser.name : 'noname';
 
   const toggleContent = () => {
     setIsExpanded(!isExpanded);
@@ -20,39 +32,45 @@ const OutputCard: FC<OutputCardProps> = ({ output }) => {
     }
   }, []);
 
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
-
-  const outputCreatedAt = output.created_at;
-  const formattedCreateDate = formatDate(outputCreatedAt);
-
-  const USER_PROFILE_HEIGHT = 32;
-  const USER_PROFILE_WIDTH = 32;
-
   return (
-    <div key={output.id} className='w-full bg-gray-50 rounded-md p-6 mb-4 relative'>
-      <Link href={`/outputs/${output.id}`}>
-        <div className='flex items-center mb-2'>
-          <UserProfile
-            user={sessionUser}
-            height={USER_PROFILE_HEIGHT}
-            width={USER_PROFILE_WIDTH}
-            isHeader={false}
-            created_at={formattedCreateDate}
+    <div key={output.id} className='px-6'>
+      <div className='py-3 border-b-2 border-gray-100'>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center flex-grow pr-2 min-w-0'>
+            {sessionUser && (
+              <ImageWrapper
+                src={USER_PROFILE_SRC_PATH}
+                height={USER_PROFILE_HEIGHT}
+                width={USER_PROFILE_WIDTH}
+                alt={USER_PROFILE_NAME}
+                className='rounded-full mr-2'
+              />
+            )}
+          </div>
+          <div className='flex items-center flex-shrink-0'>
+            <Link href={`/outputs/${output.id}`}>
+              <div className='flex items-center border border-gray-300 rounded-full py-1 pl-1 pr-2 cursor-pointer mr-2 hover:bg-gray-50'>
+                <EditIcon className='rounded-full bg-orange-500 text-gray-50' fontSize='small' />
+                <div className='text-sm text-gray-700 ml-1'>詳細</div>
+              </div>
+            </Link>
+            <div className='text-sm text-gray-500'>{formattedCreateDate}</div>
+          </div>
+        </div>
+        <div className='relative'>
+          <div
+            ref={contentRef}
+            style={{ maxHeight: isExpanded ? 'none' : '400px', overflow: 'hidden' }}
+            className='OutputCardContent text-sm truncate pt-3'
+            dangerouslySetInnerHTML={{ __html: output.content }}
           />
+          {showMoreButton && !isExpanded && (
+            <div className='MoreButton' onClick={toggleContent}>
+              もっと見る
+            </div>
+          )}
         </div>
-        <div
-          ref={contentRef}
-          style={{ maxHeight: isExpanded ? 'none' : '400px', overflow: 'hidden' }}
-          className='OutputCardContent'
-          dangerouslySetInnerHTML={{ __html: output.content }}
-        />
-      </Link>
-      {showMoreButton && !isExpanded && (
-        <div className='MoreButton' onClick={toggleContent}>
-          もっと見る
-        </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/features/outputs/components/OutputCard.tsx
+++ b/features/outputs/components/OutputCard.tsx
@@ -11,8 +11,7 @@ const OutputCard: FC<OutputCardProps> = ({ output }) => {
   const [showMoreButton, setShowMoreButton] = useState<boolean>(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
+  const { sessionUser } = useContext(SessionContext);
 
   const outputCreatedAt = output.created_at;
   const formattedCreateDate = formatDate(outputCreatedAt);

--- a/features/outputs/components/OutputCard.tsx
+++ b/features/outputs/components/OutputCard.tsx
@@ -5,6 +5,7 @@ import { formatDate } from '@/common/functions/dateUtils';
 import ImageWrapper from '@/components/ui-elements/ImageWrapper';
 import EditIcon from '@mui/icons-material/Edit';
 import Link from 'next/link';
+import { USER_PROFILE_HEIGHT_SM, USER_PROFILE_WIDTH_SM } from '@/common/constans/sizes';
 
 const OutputCard: FC<OutputCardProps> = ({ output }) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
@@ -16,10 +17,8 @@ const OutputCard: FC<OutputCardProps> = ({ output }) => {
   const outputCreatedAt = output.created_at;
   const formattedCreateDate = formatDate(outputCreatedAt);
 
-  const USER_PROFILE_HEIGHT = 32;
-  const USER_PROFILE_WIDTH = 32;
-  const USER_PROFILE_SRC_PATH = sessionUser && sessionUser.profile_image_path !== null ? sessionUser.profile_image_path : '/no_image.png';
-  const USER_PROFILE_NAME = sessionUser && sessionUser.name !== null ? sessionUser.name : 'noname';
+  const userProfileSrcPath = sessionUser && sessionUser.profile_image_path !== null ? sessionUser.profile_image_path : '/no_image.png';
+  const userProfileName = sessionUser && sessionUser.name !== null ? sessionUser.name : 'noname';
 
   const toggleContent = () => {
     setIsExpanded(!isExpanded);
@@ -38,10 +37,10 @@ const OutputCard: FC<OutputCardProps> = ({ output }) => {
           <div className='flex items-center flex-grow pr-2 min-w-0'>
             {sessionUser && (
               <ImageWrapper
-                src={USER_PROFILE_SRC_PATH}
-                height={USER_PROFILE_HEIGHT}
-                width={USER_PROFILE_WIDTH}
-                alt={USER_PROFILE_NAME}
+                src={userProfileSrcPath}
+                height={USER_PROFILE_HEIGHT_SM}
+                width={USER_PROFILE_WIDTH_SM}
+                alt={userProfileName}
                 className='rounded-full mr-2'
               />
             )}

--- a/features/outputs/components/OutputList.tsx
+++ b/features/outputs/components/OutputList.tsx
@@ -1,29 +1,41 @@
-import { FormContext } from '@/context/FormContext';
 import React, { FC, useContext } from 'react'
+import { FormContext } from '@/context/FormContext';
 import { OutputProps, OutputsProps } from '../types/output';
 import OutputCard from './OutputCard';
+import AddIcon from '@mui/icons-material/Add';
 
 const OutputList: FC<OutputsProps> = ({ outputs }) => {
   const { setFormOpen, setFormType } = useContext(FormContext);
 
-  const handleFormOpen = () => {
+  const handleNewFormOpen = () => {
     setFormType('createOutput');
     setFormOpen(true);
   };
 
   return (
-    <div className='w-full max-w-[980px] m-auto pb-10'>
-      <button
-        className='block bg-blue-500 text-blue-100 hover:bg-blue-600 text-sm font-bold rounded-full p-2 ml-auto w-[150px] text-center cursor-pointer'
-        onClick={handleFormOpen}
-      >
-        アウトプット追加
-      </button>
-      <div className='flex justify-between flex-wrap mt-8'>
-        {outputs && outputs.length > 0 ? (
-          outputs.map((output: OutputProps) => <OutputCard key={output.id} output={output} />)
+    <div className='bg-white rounded-md shadow-sm border border-gray-300 mt-8'>
+      <div className='flex justify-between items-center p-6 border-b-2 border-gray-100'>
+        <div className='text-md text-gray-700'>アウトプット一覧</div>
+        <div
+          className='flex items-center border border-gray-300 rounded-full py-1 pl-1 pr-2 cursor-pointer hover:bg-gray-50'
+          onClick={handleNewFormOpen}
+        >
+          <AddIcon className='rounded-full bg-blue-500 text-gray-50' fontSize='small' />
+          <div className='text-sm text-gray-700 ml-1'>追加</div>
+        </div>
+      </div>
+      <div className='py-6'>
+        { outputs && outputs.length > 0 ? (
+          outputs.map((output: OutputProps) => (
+            <OutputCard key={output.id} output={output} />
+          ))
         ) : (
-          <p>アウトプットがありません。</p>
+          <div className='p-6 text-gray-700 text-sm'>アウトプットの投稿がありません</div>
+        )}
+        { outputs && outputs.length > 10 && (
+          <div className='pt-4 px-6'>
+            <div className='text-sm text-gray-900 py-2 px-4 cursor-pointer inline-block hover:bg-gray-50'>もっと表示</div>
+          </div>
         )}
       </div>
     </div>

--- a/features/stacks/components/StackCard.tsx
+++ b/features/stacks/components/StackCard.tsx
@@ -12,6 +12,7 @@ import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import { StackIntrospectionContext } from '@/features/introspections/contexts/StackIntrospectionContext';
 import { InitialIntrospectionFormData } from '@/features/introspections/functions/form';
+import { USER_PROFILE_HEIGHT_SM, USER_PROFILE_WIDTH_SM } from '@/common/constans/sizes';
 
 const StackCard: FC<StackCardProps> = ({ stack }) => {
   const stackedAt = stack.stacked_at;
@@ -40,10 +41,9 @@ const StackCard: FC<StackCardProps> = ({ stack }) => {
 
   const [introspectionValue, setIntrospectionValue] = useState<IntrospectionProps>(undefined);
 
-  const USER_PROFILE_HEIGHT = 26;
-  const USER_PROFILE_WIDTH = 26;
-  const USER_PROFILE_SRC_PATH =
+  const userProfileSrcPath =
     stack.user.profile_image_path !== null ? stack.user.profile_image_path : '/no_image.png';
+  const userProfileName = stack.user.name && stack.user.name !== null ? stack.user.name : 'noname';
 
   useEffect(() => {
     const fetchIntrospection = async () => {
@@ -68,10 +68,10 @@ const StackCard: FC<StackCardProps> = ({ stack }) => {
         <div className='flex items-center flex-grow pr-2 min-w-0'>
           {sessionUser && (
             <ImageWrapper
-              src={USER_PROFILE_SRC_PATH}
-              height={USER_PROFILE_HEIGHT}
-              width={USER_PROFILE_WIDTH}
-              alt={stack.user.name}
+              src={userProfileSrcPath}
+              height={USER_PROFILE_HEIGHT_SM}
+              width={USER_PROFILE_WIDTH_SM}
+              alt={userProfileName}
               className='rounded-full mr-2'
             />
           )}

--- a/features/stacks/components/StackCard.tsx
+++ b/features/stacks/components/StackCard.tsx
@@ -17,8 +17,7 @@ const StackCard: FC<StackCardProps> = ({ stack }) => {
   const stackedAt = stack.stacked_at;
   const formattedStackedDate = formatDate(stackedAt);
 
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
+  const { sessionUser } = useContext(SessionContext);
 
   const formContext = useContext(FormContext);
   const { setFormOpen, setFormType, isRegisterEvent } = formContext;

--- a/features/stacks/components/StackList.tsx
+++ b/features/stacks/components/StackList.tsx
@@ -4,8 +4,7 @@ import { StackProps } from '../types/stack';
 import { SessionContext } from '@/context/SessionContext';
 
 const StackList: FC<{ stacks: StackProps[] }> = ({ stacks }) => {
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
+  const { sessionUser } = useContext(SessionContext);
 
   if (!sessionUser) {
     return <div>Loading...</div>;

--- a/features/teams/components/TeamList.tsx
+++ b/features/teams/components/TeamList.tsx
@@ -11,8 +11,7 @@ const TeamList: FC = () => {
   const [teams, setTeams] = useState<TeamProps[]>([]);
   const formContext = useContext(FormContext);
   const { setFormOpen, setFormType, isRegisterEvent } = formContext;
-  const sessionContext = useContext(SessionContext);
-  const { isAdmin } = sessionContext;
+  const { isAdmin } = useContext(SessionContext);
 
   useEffect(() => {
     const fetchTeams = async () => {

--- a/features/teams/components/TeamListItem.tsx
+++ b/features/teams/components/TeamListItem.tsx
@@ -15,8 +15,7 @@ const TeamListItem: FC<TeamFormDataParams> = ({ id, name }) => {
   const { setTeamFormData } = useContext(TeamFormContext);
   const { setInviteTeamFormData } = useContext(InviteTeamFormContext);
 
-  const sessionContext = useContext(SessionContext);
-  const { isAdmin } = sessionContext;
+  const { isAdmin } = useContext(SessionContext);
 
   const handleFormOpen = () => {
     setFormOpen(true);

--- a/features/users/components/ProfileCard.tsx
+++ b/features/users/components/ProfileCard.tsx
@@ -4,6 +4,7 @@ import { FormContext } from '@/context/FormContext';
 import { SessionContext } from '@/context/SessionContext';
 import AddAPhotoIcon from '@mui/icons-material/AddAPhoto';
 import ProfileImageModal from './ProfileImageModal';
+import { USER_PROFILE_HEIGHT_LG, USER_PROFILE_WIDTH_LG } from '@/common/constans/sizes';
 
 const ProfileCard: FC = () => {
   const { sessionUser } = useContext(SessionContext);
@@ -17,10 +18,9 @@ const ProfileCard: FC = () => {
     setIsProfileImageModal(true);
   };
 
-  const USER_PROFILE_HEIGHT = 180;
-  const USER_PROFILE_WIDTH = 180;
-  const USER_PROFILE_SRC_PATH =
+  const userProfileSrcPath =
     sessionUser && sessionUser.profile_image_path !== null ? sessionUser.profile_image_path : '/no_image.png';
+  const userProfileName = sessionUser && sessionUser.name !== null ? sessionUser.name : 'noname';
 
   const handleFormOpen = () => {
     setFormType('updateUser');
@@ -32,10 +32,10 @@ const ProfileCard: FC = () => {
       <div className='flex items-center'>
         <div className='ProfileImage' onClick={handleProfileImageModalOpen}>
           <ImageWrapper
-            src={USER_PROFILE_SRC_PATH}
-            height={USER_PROFILE_HEIGHT}
-            width={USER_PROFILE_WIDTH}
-            alt={sessionUser.name}
+            src={userProfileSrcPath}
+            height={USER_PROFILE_HEIGHT_LG}
+            width={USER_PROFILE_WIDTH_LG}
+            alt={userProfileName}
             className='rounded-full'
           />
           <div className='ProfileImageOverlay'>

--- a/features/users/components/ProfileCard.tsx
+++ b/features/users/components/ProfileCard.tsx
@@ -6,8 +6,7 @@ import AddAPhotoIcon from '@mui/icons-material/AddAPhoto';
 import ProfileImageModal from './ProfileImageModal';
 
 const ProfileCard: FC = () => {
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
+  const { sessionUser } = useContext(SessionContext);
 
   const formContext = useContext(FormContext);
   const { setFormOpen, setFormType } = formContext;

--- a/features/users/components/ProfileImageModal.tsx
+++ b/features/users/components/ProfileImageModal.tsx
@@ -9,6 +9,7 @@ import Box from '@mui/material/Box';
 import Modal from '@mui/material/Modal';
 import ImageWrapper from '@/components/ui-elements/ImageWrapper';
 import axios from 'axios';
+import { USER_PROFILE_HEIGHT_MD, USER_PROFILE_WIDTH_MD } from '@/common/constans/sizes';
 
 const ProfileImageModal: FC<ProfileModalState> = ({ isProfileImageModal, setIsProfileImageModal }) => {
   const sessiontContext = useContext(SessionContext);
@@ -119,11 +120,9 @@ const ProfileImageModal: FC<ProfileModalState> = ({ isProfileImageModal, setIsPr
     }
   };
 
-  const USER_PROFILE_HEIGHT = 100;
-  const USER_PROFILE_WIDTH = 100;
-  const USER_PROFILE_SRC_PATH =
+  const userProfileSrcPath =
     sessionUser && sessionUser.profile_image_path !== null ? sessionUser.profile_image_path : '/no_image.png';
-  const USER_PROFILE_NAME = sessionUser && sessionUser.name !== null ? sessionUser.name : 'noname';
+  const userProfileName = sessionUser && sessionUser.name !== null ? sessionUser.name : 'noname';
 
   return (
     <div onClick={handleClickOutside}>
@@ -134,10 +133,10 @@ const ProfileImageModal: FC<ProfileModalState> = ({ isProfileImageModal, setIsPr
         >
           <div className='flex justify-center mb-6'>
             <ImageWrapper
-              src={USER_PROFILE_SRC_PATH}
-              height={USER_PROFILE_HEIGHT}
-              width={USER_PROFILE_WIDTH}
-              alt={USER_PROFILE_NAME}
+              src={userProfileSrcPath}
+              height={USER_PROFILE_HEIGHT_MD}
+              width={USER_PROFILE_WIDTH_MD}
+              alt={userProfileName}
             />
           </div>
           <button

--- a/pages/outputs/[output].tsx
+++ b/pages/outputs/[output].tsx
@@ -22,8 +22,7 @@ const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
   const createAt = output.created_at;
   const formattedStackedDate = formatDate(createAt);
 
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
+  const { sessionUser } = useContext(SessionContext);
 
   // TODO: 現状は仮情報を使用しており、アウトプットにユーザー紐づけたら更新
   const USER_PROFILE_HEIGHT = 26;

--- a/pages/outputs/[output].tsx
+++ b/pages/outputs/[output].tsx
@@ -14,6 +14,7 @@ import OutputCommentCard from '@/features/outputs/comments/components/OutputComm
 import ImageWrapper from '@/components/ui-elements/ImageWrapper';
 import { SessionContext } from '@/context/SessionContext';
 import { formatDate } from '@/common/functions/dateUtils';
+import { USER_PROFILE_HEIGHT_SM, USER_PROFILE_WIDTH_SM } from '@/common/constans/sizes';
 
 const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
   const router = useRouter();
@@ -25,10 +26,8 @@ const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
   const { sessionUser } = useContext(SessionContext);
 
   // TODO: 現状は仮情報を使用しており、アウトプットにユーザー紐づけたら更新
-  const USER_PROFILE_HEIGHT = 26;
-  const USER_PROFILE_WIDTH = 26;
-  const USER_PROFILE_SRC_PATH = '/no_image.png';
-  const USER_PROFILE_NAME = 'example';
+  const userProfileSrcPath = '/no_image.png';
+  const userProfileName = 'example';
 
   const [comments, setComments] = useState(initialComments);
   const { setFormOpen, setFormType } = useContext(FormContext);
@@ -58,10 +57,10 @@ const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
                 <div className='text-[12px] text-gray-500 w-[150px]'>投稿者</div>
                 <div className='flex items-center'>
                   <ImageWrapper
-                    src={USER_PROFILE_SRC_PATH}
-                    height={USER_PROFILE_HEIGHT}
-                    width={USER_PROFILE_WIDTH}
-                    alt={USER_PROFILE_NAME}
+                    src={userProfileSrcPath}
+                    height={USER_PROFILE_HEIGHT_SM}
+                    width={USER_PROFILE_WIDTH_SM}
+                    alt={userProfileName}
                     className='rounded-full'
                   />
                   <div className='ml-2 text-sm'>{sessionUser?.name}</div>

--- a/pages/outputs/index.tsx
+++ b/pages/outputs/index.tsx
@@ -9,11 +9,11 @@ import { OutputsProps } from '@/features/outputs/types/output';
 
 const Index: NextPage<OutputsProps> = ({ outputs }) => {
   return (
-    <div>
-      <Layout>
+    <Layout>
+      <div className='max-w-[1020px] m-auto'>
         <OutputList outputs={outputs} />
-      </Layout>
-    </div>
+      </div>
+    </Layout>
   );
 };
 

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -14,8 +14,7 @@ const Index: NextPage = () => {
   const [skills, setSkills] = useState<string[]>([]);
   const [minutes, setMinutes] = useState<number[]>([]);
 
-  const sessionContext = useContext(SessionContext);
-  const { sessionUser } = sessionContext;
+  const { sessionUser } = useContext(SessionContext);
 
   useEffect(() => {
     const options = getApiHeadersWithUserId();


### PR DESCRIPTION
## Epic


## PBI
[アウトプット詳細にヘッダー・サイドバーを追加する](https://app.asana.com/0/1204548322306328/1206166933240808/f)

## 対象画面キャプチャ
https://github.com/mnmuu8/frontend_stack/assets/121008362/68e46917-90ee-40ba-8cfe-c58311daf11e

## 実行するコマンド
なし

## やったこと
- アウトプット一覧ページのレイアウト変更
- アウトプット詳細ページのレイアウト変更
  - Layoutコンポーネント利用してヘッダー・サイドバーを表示
  - コメントをコンポーネント化して表示

## このPRでやらないこと
- アウトプット投稿とユーザーの紐付け
- アウトプットコメントとユーザーの紐付け

## 動作確認
- [x] 確認済み

## その他
なし