### PR TITLE
アウトプット時に画像挿入を行えるようにした

### DIFF
--- a/features/outputs/rich_editors/components/RichTextEditor.tsx
+++ b/features/outputs/rich_editors/components/RichTextEditor.tsx
@@ -21,24 +21,28 @@ import { handleBeforeInput,
 import { stateToHTML } from 'draft-js-export-html';
 import { OutputFormContext } from '../../contexts/OutputFormContext';
 import ToolbarButtons from './ToolbarButtons';
+import { ProcessFileDropEventProps } from '../../types/editor';
 
 const RichTextEditor: FC = () => {
   const [editorState, setEditorState] = useState(() => EditorState.createEmpty());
 
   const { setOutputFormData } = useContext(OutputFormContext);
 
+  const processFileDropEvent = ({ item, editorState, setEditorState }: ProcessFileDropEventProps) => {
+    if (item.kind !== 'file') return;
+  
+    const file = item.getAsFile();
+    if (file) insertImageToEditor({ file, editorState, setEditorState });
+  };
+
   const handleFileDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const dataTransferItems = e.dataTransfer.items;
-    if (dataTransferItems) {
-      for (let i = 0; i < dataTransferItems.length; i++) {
-        if (dataTransferItems[i].kind === 'file') {
-          const file = dataTransferItems[i].getAsFile();
-          if (file) {
-            insertImageToEditor({file, editorState, setEditorState})
-          }
-        }
-      }
+    if ( !dataTransferItems ) return;
+
+    for (let i = 0; i < dataTransferItems.length; i++) {
+      const item = dataTransferItems[i];
+      processFileDropEvent({item, editorState, setEditorState})
     }
   };
 

--- a/features/outputs/rich_editors/components/RichTextEditor.tsx
+++ b/features/outputs/rich_editors/components/RichTextEditor.tsx
@@ -15,6 +15,7 @@ import { handleBeforeInput,
   handleKeyCommand,
   handlePastedText,
   handleReturn,
+  insertImageToEditor,
   keyBindingFn,
 } from '../functions/editorOptions';
 import { stateToHTML } from 'draft-js-export-html';
@@ -25,6 +26,21 @@ const RichTextEditor: FC = () => {
   const [editorState, setEditorState] = useState(() => EditorState.createEmpty());
 
   const { setOutputFormData } = useContext(OutputFormContext);
+
+  const handleFileDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const dataTransferItems = e.dataTransfer.items;
+    if (dataTransferItems) {
+      for (let i = 0; i < dataTransferItems.length; i++) {
+        if (dataTransferItems[i].kind === 'file') {
+          const file = dataTransferItems[i].getAsFile();
+          if (file) {
+            insertImageToEditor({file, editorState, setEditorState})
+          }
+        }
+      }
+    }
+  };
 
   const [plugins] = useMemo(() => {
     const linkifyPlugin = createLinkifyPlugin({
@@ -56,7 +72,11 @@ const RichTextEditor: FC = () => {
   return (
     <div className='mt-4'>
       <ToolbarButtons editorState={editorState} setEditorState={setEditorState} />
-      <div className='shadow-sm border-b border-l border-r border-gray-300 rounded-b-md text-md overflow-scroll h-[420px] p-3 prose prose-stone'>
+      <div
+        onDrop={handleFileDrop}
+        onDragOver={(e) => e.preventDefault()}
+        className='shadow-sm border-b border-l border-r border-gray-300 rounded-b-md text-md overflow-scroll h-[420px] p-3 prose prose-stone'
+      >
         <Editor
           editorState={editorState}
           onChange={setEditorState}

--- a/features/outputs/rich_editors/components/ToolbarButtons.tsx
+++ b/features/outputs/rich_editors/components/ToolbarButtons.tsx
@@ -1,5 +1,5 @@
-import React, { Dispatch, FC, SetStateAction, useRef } from 'react'
-import { AtomicBlockUtils, EditorState, RichUtils } from 'draft-js';
+import React, { FC, useRef } from 'react'
+import { RichUtils } from 'draft-js';
 
 import {
   FormatBold,
@@ -12,11 +12,8 @@ import {
   Terminal,
   InsertPhoto,
 } from '@mui/icons-material/';
-
-type ToolbarButtonsProps = {
-  editorState: EditorState;
-  setEditorState: Dispatch<SetStateAction<EditorState>>;
-};
+import { ToolbarButtonsProps } from '../../types/editor';
+import { insertImageToEditor } from '../functions/editorOptions';
 
 const ToolbarButtons: FC<ToolbarButtonsProps> = ({ setEditorState, editorState }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -24,23 +21,10 @@ const ToolbarButtons: FC<ToolbarButtonsProps> = ({ setEditorState, editorState }
     if (fileInputRef.current) fileInputRef.current.click();
   };
 
-  const insertImage = (file: File) => {
-    const imageUrl = URL.createObjectURL(file);
-    const contentState = editorState.getCurrentContent();
-    const contentStateWithEntity = contentState.createEntity(
-      'IMAGE',
-      'IMMUTABLE',
-      { src: imageUrl }
-    );
-    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
-    const newEditorState = EditorState.set(editorState, { currentContent: contentStateWithEntity });
-    const newState = AtomicBlockUtils.insertAtomicBlock(newEditorState, entityKey, ' ');
-    setEditorState(newState);
-  };
-
   const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if ( e.target.files ) {
-      insertImage(e.target.files[0]);
+      const file = e.target.files[0];
+      insertImageToEditor({file, editorState, setEditorState});
       e.target.value = '';
     }
   };

--- a/features/outputs/rich_editors/components/ToolbarButtons.tsx
+++ b/features/outputs/rich_editors/components/ToolbarButtons.tsx
@@ -1,0 +1,88 @@
+import React, { Dispatch, FC, SetStateAction, useRef } from 'react'
+import { AtomicBlockUtils, EditorState, RichUtils } from 'draft-js';
+
+import {
+  FormatBold,
+  FormatItalic,
+  FormatUnderlined,
+  FormatListBulleted,
+  FormatListNumbered,
+  FormatQuote,
+  Code,
+  Terminal,
+  InsertPhoto,
+} from '@mui/icons-material/';
+
+type ToolbarButtonsProps = {
+  editorState: EditorState;
+  setEditorState: Dispatch<SetStateAction<EditorState>>;
+};
+
+const ToolbarButtons: FC<ToolbarButtonsProps> = ({ setEditorState, editorState }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const handleFileOpen = () => {
+    if (fileInputRef.current) fileInputRef.current.click();
+  };
+
+  const insertImage = (file: File) => {
+    const imageUrl = URL.createObjectURL(file);
+    const contentState = editorState.getCurrentContent();
+    const contentStateWithEntity = contentState.createEntity(
+      'IMAGE',
+      'IMMUTABLE',
+      { src: imageUrl }
+    );
+    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+    const newEditorState = EditorState.set(editorState, { currentContent: contentStateWithEntity });
+    const newState = AtomicBlockUtils.insertAtomicBlock(newEditorState, entityKey, ' ');
+    setEditorState(newState);
+  };
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if ( e.target.files ) {
+      insertImage(e.target.files[0]);
+      e.target.value = '';
+    }
+  };
+
+  const applyCustomInlineStyle = (style: string) => {
+    setEditorState(RichUtils.toggleInlineStyle(editorState, style));
+  };
+
+  const applyCustomBlockType = (type: string) => {
+    setEditorState(RichUtils.toggleBlockType(editorState, type));
+  };
+
+  const toolbarButtons = [
+    { action: applyCustomInlineStyle, styleType: 'BOLD', IconComponent: FormatBold },
+    { action: applyCustomInlineStyle, styleType: 'ITALIC', IconComponent: FormatItalic },
+    { action: applyCustomInlineStyle, styleType: 'UNDERLINE', IconComponent: FormatUnderlined },
+    { action: applyCustomInlineStyle, styleType: 'CODE', IconComponent: Code },
+    { action: applyCustomBlockType, styleType: 'unordered-list-item', IconComponent: FormatListBulleted },
+    { action: applyCustomBlockType, styleType: 'ordered-list-item', IconComponent: FormatListNumbered },
+    { action: applyCustomBlockType, styleType: 'blockquote', IconComponent: FormatQuote },
+    { action: applyCustomBlockType, styleType: 'code-block', IconComponent: Terminal },
+  ];
+
+  return (
+    <div className='flex items-center px-2 py-1 rounded-t-md border-t border-l border-r border-gray-300 bg-gray-100 space-x-1 w-full'>
+      {toolbarButtons.map(({ action, styleType, IconComponent }) => (
+        <button key={styleType} onClick={() => action(styleType)} className='hover:bg-gray-200 px-1 rounded-sm'>
+          <IconComponent fontSize='small' />
+        </button>
+      ))}
+      <button onClick={handleFileOpen} className='hover:bg-gray-200 px-1 rounded-sm'>
+        <InsertPhoto fontSize='small' />
+        <input
+          type="file"
+          onChange={handleFileInput}
+          accept="image/png, image/jpeg"
+          className='hidden'
+          ref={fileInputRef} 
+        />
+      </button>
+    </div>
+  )
+}
+
+export default ToolbarButtons

--- a/features/outputs/rich_editors/functions/editorOptions.ts
+++ b/features/outputs/rich_editors/functions/editorOptions.ts
@@ -1,5 +1,5 @@
-import { EditorState, Modifier, SelectionState, getDefaultKeyBinding } from "draft-js";
-import { HandleBeforeInputProps, handleKeyCommandProps, handlePastedTextProps, handleReturnProps, keyBindingFnProps } from "../../types/editor";
+import { AtomicBlockUtils, EditorState, Modifier, SelectionState, getDefaultKeyBinding } from "draft-js";
+import { HandleBeforeInputProps, InsertImageToEditorProps, handleKeyCommandProps, handlePastedTextProps, handleReturnProps, keyBindingFnProps } from "../../types/editor";
 
 export const handleReturn = ({ editorState, setEditorState }: handleReturnProps) => {
   const selection = editorState.getSelection();
@@ -118,4 +118,14 @@ export const handleBeforeInput = ({ chars, editorState, setEditorState}: HandleB
   }
 
   return 'not-handled';
+};
+
+export const insertImageToEditor = ({ file, editorState, setEditorState} :InsertImageToEditorProps) => {
+  const imageUrl = URL.createObjectURL(file);
+  const contentState = editorState.getCurrentContent();
+  const contentStateWithEntity = contentState.createEntity('IMAGE', 'IMMUTABLE', { src: imageUrl });
+  const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+  const newEditorState = EditorState.set(editorState, { currentContent: contentStateWithEntity });
+  const newState = AtomicBlockUtils.insertAtomicBlock(newEditorState, entityKey, ' ');
+  setEditorState(newState);
 };

--- a/features/outputs/types/editor.ts
+++ b/features/outputs/types/editor.ts
@@ -34,3 +34,7 @@ export type ToolbarButtonsProps = EditorStateProps & SetEditorStateProps;
 export type InsertImageToEditorProps = EditorStateProps & SetEditorStateProps & {
   file: File;
 };
+
+export type ProcessFileDropEventProps = EditorStateProps & SetEditorStateProps & {
+  item: DataTransferItem;
+};

--- a/features/outputs/types/editor.ts
+++ b/features/outputs/types/editor.ts
@@ -28,3 +28,9 @@ export type HandleBeforeInputProps = EditorStateProps &
   SetEditorStateProps & {
     chars: string;
   };
+
+export type ToolbarButtonsProps = EditorStateProps & SetEditorStateProps;
+
+export type InsertImageToEditorProps = EditorStateProps & SetEditorStateProps & {
+  file: File;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.4",
+        "@draft-js-plugins/image": "^4.1.4",
         "@draft-js-plugins/inline-toolbar": "^4.2.1",
         "@draft-js-plugins/linkify": "^4.2.2",
         "@emotion/react": "^11.11.1",
@@ -614,6 +615,27 @@
         "draft-js": "^0.11.0",
         "react": "^16.8.0 || ^17.0.0 || >=18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@draft-js-plugins/image": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/image/-/image-4.1.4.tgz",
+      "integrity": "sha512-gLEYjhG2n9v5Y+e9sH9OD0/XVbHOaBwSBo3loXScmwSOTFP+9GBwp6HxCXvnBJj15SOQqGVvEkf6W3Jlzu/8ng==",
+      "dependencies": {
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "draft-js": "^0.10.1 || ^0.11.0",
+        "react": "^16.8.0 || ^17.0.0 || >=18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@draft-js-plugins/image/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@draft-js-plugins/inline-toolbar": {
@@ -7369,6 +7391,21 @@
       "requires": {
         "immutable": "~3.7.4",
         "prop-types": "^15.8.1"
+      }
+    },
+    "@draft-js-plugins/image": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@draft-js-plugins/image/-/image-4.1.4.tgz",
+      "integrity": "sha512-gLEYjhG2n9v5Y+e9sH9OD0/XVbHOaBwSBo3loXScmwSOTFP+9GBwp6HxCXvnBJj15SOQqGVvEkf6W3Jlzu/8ng==",
+      "requires": {
+        "clsx": "^1.2.1"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        }
       }
     },
     "@draft-js-plugins/inline-toolbar": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@draft-js-plugins/editor": "^4.1.4",
+    "@draft-js-plugins/image": "^4.1.4",
     "@draft-js-plugins/inline-toolbar": "^4.2.1",
     "@draft-js-plugins/linkify": "^4.2.2",
     "@emotion/react": "^11.11.1",


### PR DESCRIPTION
## Epic
[画像付きのアウトプットができるようになる](https://app.asana.com/0/1204548322306328/1206166932207794/f)

## PBI
[アウトプット時に画像を挿入できるようにする](https://app.asana.com/0/1204548322306328/1206234783743748/f)

## 対象画面キャプチャ
https://github.com/mnmuu8/frontend_stack/assets/121008362/ae7e097f-e69a-4028-ae26-011fb823e2f7

## 実行するコマンド


## やったこと
- エディタに画像を挿入できるようにした
- 画像をDragnDropで挿入できるようにした
- 画像はpng/jpeg/jpgのみ許容するようにした

## このPRでやらないこと
- 画像をDBに保存する

## 動作確認
- [x] 確認済み

## その他
