### PR TITLE
積み上げ作成・更新APIで「完了したかどうか」のフラグを持たせるようにした

### DIFF
--- a/generated-api/apis/StackApi.ts
+++ b/generated-api/apis/StackApi.ts
@@ -16,9 +16,6 @@
 import * as runtime from '../runtime';
 import type {
   StacksCreateRequestBody,
-  StacksIntrospectionCreateRequestBody,
-  StacksIntrospectionUpdateRequestBody,
-  StacksIntrospectionsIntrospection,
   StacksStack,
   StacksStackListInner,
   StacksUpdateRequestBody,
@@ -26,12 +23,6 @@ import type {
 import {
     StacksCreateRequestBodyFromJSON,
     StacksCreateRequestBodyToJSON,
-    StacksIntrospectionCreateRequestBodyFromJSON,
-    StacksIntrospectionCreateRequestBodyToJSON,
-    StacksIntrospectionUpdateRequestBodyFromJSON,
-    StacksIntrospectionUpdateRequestBodyToJSON,
-    StacksIntrospectionsIntrospectionFromJSON,
-    StacksIntrospectionsIntrospectionToJSON,
     StacksStackFromJSON,
     StacksStackToJSON,
     StacksStackListInnerFromJSON,
@@ -51,20 +42,6 @@ export interface ApiV1StacksDestroyRequest {
 export interface ApiV1StacksIndexRequest {
     userId?: number;
     teamId?: number;
-}
-
-export interface ApiV1StacksIntrospectionsCreateRequest {
-    stackId: number;
-    stacksIntrospectionCreateRequestBody: StacksIntrospectionCreateRequestBody;
-}
-
-export interface ApiV1StacksIntrospectionsShowRequest {
-    stackId: number;
-}
-
-export interface ApiV1StacksIntrospectionsUpdateRequest {
-    stackId: number;
-    stacksIntrospectionUpdateRequestBody: StacksIntrospectionUpdateRequestBody;
 }
 
 export interface ApiV1StacksUpdateRequest {
@@ -170,110 +147,6 @@ export class StackApi extends runtime.BaseAPI {
      */
     async apiV1StacksIndex(requestParameters: ApiV1StacksIndexRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<StacksStackListInner>> {
         const response = await this.apiV1StacksIndexRaw(requestParameters, initOverrides);
-        return await response.value();
-    }
-
-    /**
-     * 積み上げの反省登録API
-     */
-    async apiV1StacksIntrospectionsCreateRaw(requestParameters: ApiV1StacksIntrospectionsCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<StacksIntrospectionsIntrospection>> {
-        if (requestParameters.stackId === null || requestParameters.stackId === undefined) {
-            throw new runtime.RequiredError('stackId','Required parameter requestParameters.stackId was null or undefined when calling apiV1StacksIntrospectionsCreate.');
-        }
-
-        if (requestParameters.stacksIntrospectionCreateRequestBody === null || requestParameters.stacksIntrospectionCreateRequestBody === undefined) {
-            throw new runtime.RequiredError('stacksIntrospectionCreateRequestBody','Required parameter requestParameters.stacksIntrospectionCreateRequestBody was null or undefined when calling apiV1StacksIntrospectionsCreate.');
-        }
-
-        const queryParameters: any = {};
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        const response = await this.request({
-            path: `/api/v1/stacks/{stack_id}/introspections`.replace(`{${"stack_id"}}`, encodeURIComponent(String(requestParameters.stackId))),
-            method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
-            body: StacksIntrospectionCreateRequestBodyToJSON(requestParameters.stacksIntrospectionCreateRequestBody),
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => StacksIntrospectionsIntrospectionFromJSON(jsonValue));
-    }
-
-    /**
-     * 積み上げの反省登録API
-     */
-    async apiV1StacksIntrospectionsCreate(requestParameters: ApiV1StacksIntrospectionsCreateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<StacksIntrospectionsIntrospection> {
-        const response = await this.apiV1StacksIntrospectionsCreateRaw(requestParameters, initOverrides);
-        return await response.value();
-    }
-
-    /**
-     * 積み上げの反省詳細API
-     */
-    async apiV1StacksIntrospectionsShowRaw(requestParameters: ApiV1StacksIntrospectionsShowRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<StacksIntrospectionsIntrospection>> {
-        if (requestParameters.stackId === null || requestParameters.stackId === undefined) {
-            throw new runtime.RequiredError('stackId','Required parameter requestParameters.stackId was null or undefined when calling apiV1StacksIntrospectionsShow.');
-        }
-
-        const queryParameters: any = {};
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        const response = await this.request({
-            path: `/api/v1/stacks/{stack_id}/introspection`.replace(`{${"stack_id"}}`, encodeURIComponent(String(requestParameters.stackId))),
-            method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => StacksIntrospectionsIntrospectionFromJSON(jsonValue));
-    }
-
-    /**
-     * 積み上げの反省詳細API
-     */
-    async apiV1StacksIntrospectionsShow(requestParameters: ApiV1StacksIntrospectionsShowRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<StacksIntrospectionsIntrospection> {
-        const response = await this.apiV1StacksIntrospectionsShowRaw(requestParameters, initOverrides);
-        return await response.value();
-    }
-
-    /**
-     * 積み上げの反省更新API
-     */
-    async apiV1StacksIntrospectionsUpdateRaw(requestParameters: ApiV1StacksIntrospectionsUpdateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<StacksIntrospectionsIntrospection>> {
-        if (requestParameters.stackId === null || requestParameters.stackId === undefined) {
-            throw new runtime.RequiredError('stackId','Required parameter requestParameters.stackId was null or undefined when calling apiV1StacksIntrospectionsUpdate.');
-        }
-
-        if (requestParameters.stacksIntrospectionUpdateRequestBody === null || requestParameters.stacksIntrospectionUpdateRequestBody === undefined) {
-            throw new runtime.RequiredError('stacksIntrospectionUpdateRequestBody','Required parameter requestParameters.stacksIntrospectionUpdateRequestBody was null or undefined when calling apiV1StacksIntrospectionsUpdate.');
-        }
-
-        const queryParameters: any = {};
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        const response = await this.request({
-            path: `/api/v1/stacks/{stack_id}/introspection`.replace(`{${"stack_id"}}`, encodeURIComponent(String(requestParameters.stackId))),
-            method: 'PATCH',
-            headers: headerParameters,
-            query: queryParameters,
-            body: StacksIntrospectionUpdateRequestBodyToJSON(requestParameters.stacksIntrospectionUpdateRequestBody),
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => StacksIntrospectionsIntrospectionFromJSON(jsonValue));
-    }
-
-    /**
-     * 積み上げの反省更新API
-     */
-    async apiV1StacksIntrospectionsUpdate(requestParameters: ApiV1StacksIntrospectionsUpdateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<StacksIntrospectionsIntrospection> {
-        const response = await this.apiV1StacksIntrospectionsUpdateRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/generated-api/models/StacksCreateRequestBody.ts
+++ b/generated-api/models/StacksCreateRequestBody.ts
@@ -55,6 +55,12 @@ export interface StacksCreateRequestBody {
      * @memberof StacksCreateRequestBody
      */
     stackedAt: Date;
+    /**
+     * 完了したかどうか
+     * @type {boolean}
+     * @memberof StacksCreateRequestBody
+     */
+    completed: boolean;
 }
 
 /**
@@ -68,6 +74,7 @@ export function instanceOfStacksCreateRequestBody(value: object): boolean {
     isInstance = isInstance && "userId" in value;
     isInstance = isInstance && "description" in value;
     isInstance = isInstance && "stackedAt" in value;
+    isInstance = isInstance && "completed" in value;
 
     return isInstance;
 }
@@ -88,6 +95,7 @@ export function StacksCreateRequestBodyFromJSONTyped(json: any, ignoreDiscrimina
         'userId': json['user_id'],
         'description': json['description'],
         'stackedAt': (new Date(json['stacked_at'])),
+        'completed': json['completed'],
     };
 }
 
@@ -106,6 +114,7 @@ export function StacksCreateRequestBodyToJSON(value?: StacksCreateRequestBody | 
         'user_id': value.userId,
         'description': value.description,
         'stacked_at': (value.stackedAt.toISOString()),
+        'completed': value.completed,
     };
 }
 

--- a/generated-api/models/StacksStack.ts
+++ b/generated-api/models/StacksStack.ts
@@ -75,6 +75,12 @@ export interface StacksStack {
      */
     stackedAt: Date;
     /**
+     * 完了したかどうか
+     * @type {boolean}
+     * @memberof StacksStack
+     */
+    completed: boolean;
+    /**
      * 
      * @type {Date}
      * @memberof StacksStack
@@ -100,6 +106,7 @@ export function instanceOfStacksStack(value: object): boolean {
     isInstance = isInstance && "skill" in value;
     isInstance = isInstance && "user" in value;
     isInstance = isInstance && "stackedAt" in value;
+    isInstance = isInstance && "completed" in value;
     isInstance = isInstance && "createdAt" in value;
     isInstance = isInstance && "updatedAt" in value;
 
@@ -123,6 +130,7 @@ export function StacksStackFromJSONTyped(json: any, ignoreDiscriminator: boolean
         'skill': StacksStackSkillFromJSON(json['skill']),
         'user': StacksStackUserFromJSON(json['user']),
         'stackedAt': (new Date(json['stacked_at'])),
+        'completed': json['completed'],
         'createdAt': (new Date(json['created_at'])),
         'updatedAt': (new Date(json['updated_at'])),
     };
@@ -144,6 +152,7 @@ export function StacksStackToJSON(value?: StacksStack | null): any {
         'skill': StacksStackSkillToJSON(value.skill),
         'user': StacksStackUserToJSON(value.user),
         'stacked_at': (value.stackedAt.toISOString()),
+        'completed': value.completed,
         'created_at': (value.createdAt.toISOString()),
         'updated_at': (value.updatedAt.toISOString()),
     };

--- a/generated-api/models/StacksStackListInner.ts
+++ b/generated-api/models/StacksStackListInner.ts
@@ -75,6 +75,12 @@ export interface StacksStackListInner {
      */
     stackedAt: Date;
     /**
+     * 完了したかどうか
+     * @type {boolean}
+     * @memberof StacksStackListInner
+     */
+    completed: boolean;
+    /**
      * 
      * @type {Date}
      * @memberof StacksStackListInner
@@ -100,6 +106,7 @@ export function instanceOfStacksStackListInner(value: object): boolean {
     isInstance = isInstance && "skill" in value;
     isInstance = isInstance && "user" in value;
     isInstance = isInstance && "stackedAt" in value;
+    isInstance = isInstance && "completed" in value;
     isInstance = isInstance && "createdAt" in value;
     isInstance = isInstance && "updatedAt" in value;
 
@@ -123,6 +130,7 @@ export function StacksStackListInnerFromJSONTyped(json: any, ignoreDiscriminator
         'skill': StacksStackSkillFromJSON(json['skill']),
         'user': StacksStackUserFromJSON(json['user']),
         'stackedAt': (new Date(json['stacked_at'])),
+        'completed': json['completed'],
         'createdAt': (new Date(json['created_at'])),
         'updatedAt': (new Date(json['updated_at'])),
     };
@@ -144,6 +152,7 @@ export function StacksStackListInnerToJSON(value?: StacksStackListInner | null):
         'skill': StacksStackSkillToJSON(value.skill),
         'user': StacksStackUserToJSON(value.user),
         'stacked_at': (value.stackedAt.toISOString()),
+        'completed': value.completed,
         'created_at': (value.createdAt.toISOString()),
         'updated_at': (value.updatedAt.toISOString()),
     };

--- a/generated-api/models/StacksUpdateRequestBody.ts
+++ b/generated-api/models/StacksUpdateRequestBody.ts
@@ -49,6 +49,12 @@ export interface StacksUpdateRequestBody {
      * @memberof StacksUpdateRequestBody
      */
     stackedAt: Date;
+    /**
+     * 完了したかどうか
+     * @type {boolean}
+     * @memberof StacksUpdateRequestBody
+     */
+    completed: boolean;
 }
 
 /**
@@ -61,6 +67,7 @@ export function instanceOfStacksUpdateRequestBody(value: object): boolean {
     isInstance = isInstance && "skillId" in value;
     isInstance = isInstance && "description" in value;
     isInstance = isInstance && "stackedAt" in value;
+    isInstance = isInstance && "completed" in value;
 
     return isInstance;
 }
@@ -80,6 +87,7 @@ export function StacksUpdateRequestBodyFromJSONTyped(json: any, ignoreDiscrimina
         'skillId': json['skill_id'],
         'description': json['description'],
         'stackedAt': (new Date(json['stacked_at'])),
+        'completed': json['completed'],
     };
 }
 
@@ -97,6 +105,7 @@ export function StacksUpdateRequestBodyToJSON(value?: StacksUpdateRequestBody | 
         'skill_id': value.skillId,
         'description': value.description,
         'stacked_at': (value.stackedAt.toISOString()),
+        'completed': value.completed,
     };
 }
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -152,7 +152,6 @@ paths:
       summary: 積み上げの反省詳細API
       operationId: api.v1.stacks.introspections.show
       tags:
-        - Stack
         - Introspection
       security: []
       parameters:
@@ -176,7 +175,6 @@ paths:
       summary: 積み上げの反省更新API
       operationId: api.v1.stacks.introspections.update
       tags:
-        - Stack
         - Introspection
       security: []
       parameters:
@@ -210,7 +208,6 @@ paths:
       summary: 積み上げの反省登録API
       operationId: api.v1.stacks.introspections.create
       tags:
-        - Stack
         - Introspection
       security: []
       parameters:

--- a/openapi.yml
+++ b/openapi.yml
@@ -989,6 +989,7 @@ components:
         - skill
         - user
         - stacked_at
+        - completed
         - created_at
         - updated_at
       properties:
@@ -1019,6 +1020,10 @@ components:
         stacked_at:
           allOf:
             - $ref: '#/components/schemas/DateTime'
+          nullable: false
+        completed:
+          allOf:
+            - $ref: '#/components/schemas/Stacks_Stack_Completed'
           nullable: false
         created_at:
           allOf:
@@ -1213,6 +1218,11 @@ components:
       type: string
       description: 積み上げ内容
       example: 積み上げ内容
+
+    Stacks_Stack_Completed:
+      type: boolean
+      description: 完了したかどうか
+      example: false
 
     Skills_SkillList:
       type: array
@@ -1766,6 +1776,7 @@ components:
         - user_id
         - description
         - stacked_at
+        - completed
       properties:
         title:
           allOf:
@@ -1791,6 +1802,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/DateTime'
           nullable: false
+        completed:
+          allOf:
+            - $ref: '#/components/schemas/Stacks_Stack_Completed'
+          nullable: false
 
     StacksUpdateRequestBody:
       type: object
@@ -1800,6 +1815,7 @@ components:
         - skill_id
         - description
         - stacked_at
+        - completed
       properties:
         title:
           allOf:
@@ -1820,6 +1836,10 @@ components:
         stacked_at:
           allOf:
             - $ref: '#/components/schemas/DateTime'
+          nullable: false
+        completed:
+          allOf:
+            - $ref: '#/components/schemas/Stacks_Stack_Completed'
           nullable: false
 
     Stacks_IntrospectionCreateRequestBody:


### PR DESCRIPTION
## Epic
[1日の計画表を感覚的に作成できる](https://app.asana.com/0/1204548322306328/1206166932207790/f)

## PBI
[積み上げに完了ステータスを付与する](https://app.asana.com/0/1204548322306328/1206482961355322/f)

## 対象画面キャプチャ


## 実行するコマンド


## やったこと
- 積み上げ作成・更新APIで「完了したかどうか」のフラグを持たせるようにした

## このPRでやらないこと
- 

## 動作確認
- [x] 確認済み

## その他
- 