### PR TITLE
積み上げ作成・更新時に完了ステータスを設定できるようにした

### DIFF
--- a/features/stacks/components/CompletedButton.tsx
+++ b/features/stacks/components/CompletedButton.tsx
@@ -1,0 +1,32 @@
+import React, { FC, useContext, useState } from 'react';
+import { ErrorMessagesState } from '@/common/types/validator';
+import { StackFormContext } from '../contexts/StackFormContext';
+import FormGroup from '@mui/material/FormGroup';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
+
+const CompletedButton: FC = () => {
+  const { stackFormData, setStackFormData } = useContext(StackFormContext);
+  const [isChecked, setIsChecked] = useState(stackFormData.completed);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newChecked = e.target.checked;
+
+    setIsChecked(newChecked);
+    setStackFormData(prevFormData => ({
+      ...prevFormData,
+      completed: newChecked,
+    }));
+  };
+
+  return (
+    <FormGroup>
+      <FormControlLabel
+        required
+        control={<Switch name='completed' checked={isChecked} onChange={handleChange} />}
+        label={isChecked ? '完了済み' : '未完了'}
+      />
+    </FormGroup>
+  );
+};
+
+export default CompletedButton;

--- a/features/stacks/components/StackCard.tsx
+++ b/features/stacks/components/StackCard.tsx
@@ -32,6 +32,7 @@ const StackCard: FC<StackCardProps> = ({ stack }) => {
   const handleEditFormOpen = () => {
     stackFormData && setStackFormData({
       id: stack.id,
+      completed: stack.completed,
       title: stack.title,
       minutes: stack.minutes,
       stacked_at: new Date(stack.stacked_at),

--- a/features/stacks/components/StackForm.tsx
+++ b/features/stacks/components/StackForm.tsx
@@ -9,7 +9,7 @@ import { dataConfirmAlert } from '@/common/functions/form';
 import FormSubmitButton from '@/components/ui-elements/FormSubmitButton';
 import FormCancelButton from '@/components/ui-elements/FormCancelButton';
 import { StackFormContext } from '@/features/stacks/contexts/StackFormContext';
-import { callCreateStack } from '../functions/api';
+import { callCreateStack } from '../functions/create';
 import { callUpdateStack } from '../functions/update';
 import { InitialStackFormData } from '../functions/form';
 import { ErrorMessages } from '@/common/types/validator';

--- a/features/stacks/components/StackFormGroup.tsx
+++ b/features/stacks/components/StackFormGroup.tsx
@@ -1,10 +1,13 @@
-import React, { FC, useContext } from 'react';
+import React, { FC, useContext, useState } from 'react';
 import DateInput from './DateInput';
 import TextInput from '@/components/ui-elements/TextInput';
 import SkillInput from '@/features/skills/components/SkillInput';
 import ErrorMessage from '@/components/ui-elements/ErrorMessage';
 import { StackFormContext } from '../contexts/StackFormContext';
 import { ErrorMessagesState } from '@/common/types/validator';
+import FormGroup from '@mui/material/FormGroup';
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
 const StackFormGroup: FC<ErrorMessagesState> = ({ errorMessages, setErrorMessages }) => {
   const { stackFormData, setStackFormData } = useContext(StackFormContext);
@@ -19,8 +22,26 @@ const StackFormGroup: FC<ErrorMessagesState> = ({ errorMessages, setErrorMessage
     });
   };
 
+  const [isChecked, setIsChecked] = useState(stackFormData.completed);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newChecked = e.target.checked;
+
+    setIsChecked(newChecked);
+    setStackFormData(prevFormData => ({
+      ...prevFormData,
+      completed: newChecked,
+    }));
+  };
+
   return (
     <>
+      <FormGroup>
+        <FormControlLabel
+          required
+          control={<Switch name='completed' checked={isChecked} onChange={handleChange} />}
+          label={isChecked ? '完了済み' : '未完了'}
+        />
+      </FormGroup>
       <SkillInput />
       <ErrorMessage errorMessages={errorMessages} errorKey={'skill'} />
       <div className='flex'>

--- a/features/stacks/components/StackFormGroup.tsx
+++ b/features/stacks/components/StackFormGroup.tsx
@@ -5,9 +5,7 @@ import SkillInput from '@/features/skills/components/SkillInput';
 import ErrorMessage from '@/components/ui-elements/ErrorMessage';
 import { StackFormContext } from '../contexts/StackFormContext';
 import { ErrorMessagesState } from '@/common/types/validator';
-import FormGroup from '@mui/material/FormGroup';
-import Switch from '@mui/material/Switch';
-import FormControlLabel from '@mui/material/FormControlLabel';
+import CompletedButton from './CompletedButton';
 
 const StackFormGroup: FC<ErrorMessagesState> = ({ errorMessages, setErrorMessages }) => {
   const { stackFormData, setStackFormData } = useContext(StackFormContext);
@@ -22,26 +20,9 @@ const StackFormGroup: FC<ErrorMessagesState> = ({ errorMessages, setErrorMessage
     });
   };
 
-  const [isChecked, setIsChecked] = useState(stackFormData.completed);
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newChecked = e.target.checked;
-
-    setIsChecked(newChecked);
-    setStackFormData(prevFormData => ({
-      ...prevFormData,
-      completed: newChecked,
-    }));
-  };
-
   return (
     <>
-      <FormGroup>
-        <FormControlLabel
-          required
-          control={<Switch name='completed' checked={isChecked} onChange={handleChange} />}
-          label={isChecked ? '完了済み' : '未完了'}
-        />
-      </FormGroup>
+      <CompletedButton />
       <SkillInput />
       <ErrorMessage errorMessages={errorMessages} errorKey={'skill'} />
       <div className='flex'>

--- a/features/stacks/functions/create.ts
+++ b/features/stacks/functions/create.ts
@@ -9,6 +9,7 @@ export const callCreateStack = async ({options, sessionData, stackFormData, setE
     stackSchema.parse(stackFormData);
 
     const params = {
+      completed: stackFormData.completed,
       title: stackFormData.title,
       description: stackFormData.description,
       minutes: stackFormData.minutes,

--- a/features/stacks/functions/form.ts
+++ b/features/stacks/functions/form.ts
@@ -1,1 +1,1 @@
-export const InitialStackFormData = {skill: "", stacked_at: new Date(), minutes: 0, title: "", description: ""}
+export const InitialStackFormData = { completed: false, skill: "", stacked_at: new Date(), minutes: 0, title: "", description: "" }

--- a/features/stacks/functions/update.ts
+++ b/features/stacks/functions/update.ts
@@ -9,6 +9,7 @@ export const callUpdateStack = async ({options, sessionData, stackFormData, setE
     stackSchema.parse(stackFormData);
 
     const params = {
+      completed: stackFormData.completed,
       title: stackFormData.title,
       description: stackFormData.description,
       minutes: stackFormData.minutes,

--- a/features/stacks/types/context.ts
+++ b/features/stacks/types/context.ts
@@ -2,6 +2,7 @@ import { Dispatch, SetStateAction } from "react";
 
 export type StackFormDataParams = {
   id?: number;
+  completed: boolean;
   skill: string;
   stacked_at: Date;
   minutes: number;

--- a/features/stacks/types/stack.ts
+++ b/features/stacks/types/stack.ts
@@ -4,6 +4,7 @@ import { UserProps } from '@/features/users/types/user';
 
 export type StackProps = {
   id: number;
+  completed: boolean;
   title: string;
   minutes: number;
   skill: SkillProps;


### PR DESCRIPTION
## Epic
[1日の計画表を感覚的に作成できる](https://github.com/users/ren0826nosuke/projects/1/views/1?pane=issue&itemId=52732130)

## PBI
[積み上げ作成・更新時に完了ステータスを設定できるようにする](https://github.com/users/ren0826nosuke/projects/1/views/1?pane=issue&itemId=52732254)

## 対象画面キャプチャ


## 実行するコマンド


## やったこと
- 積み上げ作成・更新時に完了ステータスを設定できるようにした

## このPRでやらないこと
- 

## 動作確認
- [x] 確認済み

## その他
- 