### PR TITLE
UI上でユーザー情報更新でパスワードを更新できるようにした

### DIFF
--- a/common/functions/validator.ts
+++ b/common/functions/validator.ts
@@ -60,6 +60,9 @@ export const userSchema = z.object({
   name: z.string().min(1, 'ユーザー名の入力は必須です'),
   email: emailSchema,
   profile_content: z.string().optional(),
+  current_password: passwordSchema.optional(),
+  new_password: passwordSchema.optional(),
+  new_password_confirmation: passwordSchema.optional(),
   team: z.object({
     name: z.string().min(1, 'チームの選択は必須です')
   }),

--- a/features/users/components/UserForm.tsx
+++ b/features/users/components/UserForm.tsx
@@ -9,7 +9,7 @@ import FormSubmitButton from '@/components/ui-elements/FormSubmitButton';
 import FormCancelButton from '@/components/ui-elements/FormCancelButton';
 import UserFormGroup from './UserFormGroup';
 import { UserFormContext } from '../contexts/UserFormContext';
-import { callUpdateUser } from '../functions/api';
+import { callUpdateUser } from '../functions/update';
 import { InitialUserFormData } from '../functions/form';
 import { ErrorMessages } from '@/common/types/validator';
 
@@ -35,7 +35,7 @@ const UserForm: FC = () => {
     if (!sessionData) return;
 
     const options = getApiHeaders();
-    
+
     if (!dataConfirmAlert('ユーザー情報を更新しますか？')) return;
     await callUpdateUser({ options, sessionData, userFormData, setErrorMessages })
       .then(() => {

--- a/features/users/components/UserFormGroup.tsx
+++ b/features/users/components/UserFormGroup.tsx
@@ -162,6 +162,45 @@ const UserFormGroup: FC<ErrorMessagesState> = ({ errorMessages }) => {
       />
       <ErrorMessage errorMessages={errorMessages} errorKey={'profile_content'} />
       <TextInput
+        name={'current_password'}
+        fullWidth={true}
+        multiline={false}
+        minRows={1}
+        required={false}
+        label={'現在のパスワード'}
+        placeholder={'現在のパスワードを入力してください'}
+        type='password'
+        onChange={handleFieldChange}
+        value={userFormData.current_password}
+      />
+      <ErrorMessage errorMessages={errorMessages} errorKey={'current_password'} />
+      <TextInput
+        name={'new_password'}
+        fullWidth={true}
+        multiline={false}
+        minRows={1}
+        required={false}
+        label={'新しいパスワード'}
+        placeholder={'新しいパスワードを入力してください'}
+        type='password'
+        onChange={handleFieldChange}
+        value={userFormData.new_password}
+      />
+      <ErrorMessage errorMessages={errorMessages} errorKey={'new_password'} />
+      <TextInput
+        name={'new_password_confirmation'}
+        fullWidth={true}
+        multiline={false}
+        minRows={1}
+        required={false}
+        label={'新しいパスワード（確認）'}
+        placeholder={'新しいパスワードを再度入力してください'}
+        type='password'
+        onChange={handleFieldChange}
+        value={userFormData.new_password_confirmation}
+      />
+      <ErrorMessage errorMessages={errorMessages} errorKey={'new_password_confirmation'} />
+      <TextInput
         name={'team'}
         fullWidth={true}
         multiline={false}

--- a/features/users/functions/update.ts
+++ b/features/users/functions/update.ts
@@ -1,25 +1,26 @@
 import axios from "axios";
 import { z } from 'zod';
 import { ErrorMessages } from "@/common/types/validator";
-import { CreateUserProps, UpdateUserProps } from "../types/api";
-import { userRegisterSchema, userSchema } from "@/common/functions/validator";
+import { UpdateUserProps } from "../types/api";
+import { userSchema } from "@/common/functions/validator";
 
-export const callCreateUser = async ({options, userFormData, setErrorMessages}: CreateUserProps) => {
+export const callUpdateUser = async ({options, sessionData, userFormData, setErrorMessages}: UpdateUserProps) => {
   try {
-    userRegisterSchema.parse(userFormData)
+    userSchema.parse(userFormData)
 
     const params = {
       role: userFormData.role,
       name: userFormData.name,
       email: userFormData.email,
       profile_content: userFormData.profile_content,
+      user_id: sessionData.userId,
       current_password: userFormData.current_password,
       new_password: userFormData.new_password,
       new_password_confirmation: userFormData.new_password_confirmation,
       team_id: userFormData.team.id,
     }
-    const url: string = `${process.env.API_ROOT_URL}/api/v1/users/`;
-    await axios.post(url, params, options);
+    const url: string = `${process.env.API_ROOT_URL}/api/v1/users/${sessionData.userId}`;
+    await axios.patch(url, params, options);
   } catch (error) {
     if (error instanceof z.ZodError) {
       const newErrors: ErrorMessages = {};

--- a/features/users/types/context.ts
+++ b/features/users/types/context.ts
@@ -8,6 +8,9 @@ export type UserFormDataParams = {
   profile_content: string;
   password?: string;
   password_confirmation?: string;
+  current_password?: string;
+  new_password?: string;
+  new_password_confirmation?: string;
   team: TeamFormDataParams;
 };
 


### PR DESCRIPTION
## Epic


## PBI
[ユーザー情報更新でパスワードを更新できるようにする](https://github.com/users/ren0826nosuke/projects/1/views/1?pane=issue&itemId=52651373)

## 対象画面キャプチャ
https://github.com/mnmuu8/frontend_stack/assets/62938854/3158213e-38d1-47df-8d48-3ed013381d7c

## 実行するコマンド


## やったこと
- ユーザー情報更新でパスワードを更新できるようにした

## このPRでやらないこと
- 

## 動作確認
- [x] 確認済み

## その他
- 