### PR TITLE
プロフィール画像がデフォルト画像で固定されている部分を置き換えた

### DIFF
--- a/features/outputs/comments/components/OutputCommentCard.tsx
+++ b/features/outputs/comments/components/OutputCommentCard.tsx
@@ -10,9 +10,9 @@ const OutputCommentCard: FC<OutputCommentCardProps> = ({ comment, outputId, setC
   const formatTimeAgo = (dateString: string) => {
     const date = new Date(dateString);
     const diffInSeconds = (new Date().getTime() - date.getTime()) / 1000;
-  
+
     if (diffInSeconds < 60) return 'たった今';
-  
+
     return new Intl.DateTimeFormat('ja-JP', {
       timeZone: 'Asia/Tokyo',
       year: 'numeric', month: '2-digit', day: '2-digit',
@@ -22,13 +22,13 @@ const OutputCommentCard: FC<OutputCommentCardProps> = ({ comment, outputId, setC
 
   const timeAgo = formatTimeAgo(comment.created_at);
 
-  // TODO: 現状は仮情報を使用しており、アウトプットのコメントにユーザー紐づけたら更新
-  const userProfileSrcPath = '/no_image.png';
-  const userProfileName = 'example';
+  const user = comment.user;
+  const userProfileSrcPath = user.profile_image_path || '/no_image.png';
+  const userProfileName = user.name || 'example';
 
   const handleDelete = async () => {
     if (!dataConfirmAlert('削除したチームは復旧できません。本当に削除しますか？')) return;
-    
+
     const commentId = comment.id
     await callDeleteOutputComment(outputId, commentId)
       .then(() => {

--- a/features/outputs/types/output.ts
+++ b/features/outputs/types/output.ts
@@ -1,8 +1,10 @@
 import { Dispatch, SetStateAction } from "react";
+import { UserProps } from "@/features/users/types/user";
 
 export type OutputProps = {
   id: number;
   content: string;
+  user: UserProps;
   created_at: string;
   updated_at: string;
 };
@@ -10,13 +12,7 @@ export type OutputProps = {
 export type CommentProps = {
   id: number;
   content: string;
-  user: {
-    id: number;
-    name: string;
-    email: string;
-    created_at: string;
-    updated_at: string;
-  };
+  user: UserProps;
   created_at: string;
   updated_at: string;
 };

--- a/pages/outputs/[output].tsx
+++ b/pages/outputs/[output].tsx
@@ -29,9 +29,9 @@ const Output: NextPage<OutputCardProps> = ({ output, initialComments }) => {
 
   const { sessionUser } = useContext(SessionContext);
 
-  // TODO: 現状は仮情報を使用しており、アウトプットにユーザー紐づけたら更新
-  const userProfileSrcPath = '/no_image.png';
-  const userProfileName = 'example';
+  const user = output.user;
+  const userProfileSrcPath = user.profile_image_path || '/no_image.png';
+  const userProfileName = user.name || 'example';
 
   const [comments, setComments] = useState<CommentProps[]|undefined>(initialComments);
   const { setFormOpen, setFormType, setIsRegisterEvent } = useContext(FormContext);


### PR DESCRIPTION
## Epic


## PBI
[プロフィール画像がデフォルト画像で固定されている部分を置き換える](https://github.com/users/ren0826nosuke/projects/1/views/1?pane=issue&itemId=56306646)

## 対象画面キャプチャ
![スクリーンショット 2024-03-13 23 04 59](https://github.com/mnmuu8/frontend_stack/assets/62938854/853292ad-6d2f-416d-8740-3e5673d62760)

## 実行するコマンド


## やったこと
- プロフィール画像がデフォルト画像で固定されている部分を置き換えた

## このPRでやらないこと
- 

## 動作確認
- [x] 確認済み

## その他
- 