### PR TITLE
ユーザー情報更新APIのリクエストボディにパスワード情報を追加した

### DIFF
--- a/generated-api/models/UserUpdateRequestBody.ts
+++ b/generated-api/models/UserUpdateRequestBody.ts
@@ -51,6 +51,24 @@ export interface UserUpdateRequestBody {
      */
     role: UsersUserRole;
     /**
+     * ユーザーのパスワード
+     * @type {string}
+     * @memberof UserUpdateRequestBody
+     */
+    currentPassword: string | null;
+    /**
+     * ユーザーのパスワード
+     * @type {string}
+     * @memberof UserUpdateRequestBody
+     */
+    newPassword: string | null;
+    /**
+     * ユーザーのパスワード
+     * @type {string}
+     * @memberof UserUpdateRequestBody
+     */
+    newPasswordConfirmation: string | null;
+    /**
      * チームID
      * @type {number}
      * @memberof UserUpdateRequestBody
@@ -67,6 +85,9 @@ export function instanceOfUserUpdateRequestBody(value: object): boolean {
     isInstance = isInstance && "email" in value;
     isInstance = isInstance && "profileContent" in value;
     isInstance = isInstance && "role" in value;
+    isInstance = isInstance && "currentPassword" in value;
+    isInstance = isInstance && "newPassword" in value;
+    isInstance = isInstance && "newPasswordConfirmation" in value;
     isInstance = isInstance && "teamId" in value;
 
     return isInstance;
@@ -86,6 +107,9 @@ export function UserUpdateRequestBodyFromJSONTyped(json: any, ignoreDiscriminato
         'email': json['email'],
         'profileContent': json['profile_content'],
         'role': UsersUserRoleFromJSON(json['role']),
+        'currentPassword': json['current_password'],
+        'newPassword': json['new_password'],
+        'newPasswordConfirmation': json['new_password_confirmation'],
         'teamId': json['team_id'],
     };
 }
@@ -103,6 +127,9 @@ export function UserUpdateRequestBodyToJSON(value?: UserUpdateRequestBody | null
         'email': value.email,
         'profile_content': value.profileContent,
         'role': UsersUserRoleToJSON(value.role),
+        'current_password': value.currentPassword,
+        'new_password': value.newPassword,
+        'new_password_confirmation': value.newPasswordConfirmation,
         'team_id': value.teamId,
     };
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -1935,6 +1935,9 @@ components:
         - email
         - profile_content
         - role
+        - current_password
+        - new_password
+        - new_password_confirmation
         - team_id
       properties:
         name:
@@ -1953,6 +1956,18 @@ components:
           allOf:
             - $ref: '#/components/schemas/Users_User_Role'
           nullable: false
+        current_password:
+          allOf:
+            - $ref: '#/components/schemas/Users_User_Password'
+          nullable: true
+        new_password:
+          allOf:
+            - $ref: '#/components/schemas/Users_User_Password'
+          nullable: true
+        new_password_confirmation:
+          allOf:
+            - $ref: '#/components/schemas/Users_User_Password'
+          nullable: true
         team_id:
           allOf:
             - $ref: '#/components/schemas/Teams_Team_Id'


### PR DESCRIPTION
## Epic


## PBI
[ユーザー情報更新でパスワードを更新できるようにする](https://github.com/users/ren0826nosuke/projects/1/views/1?pane=issue&itemId=52651373)

## 対象画面キャプチャ


## 実行するコマンド


## やったこと
- ユーザー情報更新APIのリクエストボディにパスワード情報を追加した

## このPRでやらないこと
- 

## 動作確認
- [x] 確認済み

## その他
- 