### PR TITLE
予定詳細のレイアウト作成

### DIFF
--- a/components/ui-parts/FormDrawer.tsx
+++ b/components/ui-parts/FormDrawer.tsx
@@ -34,6 +34,7 @@ const FormDrawer: FC<FormDrawerProps> = ({ planInfo, drawerOpen, setDrawerOpen }
       open={drawerOpen}
       onClose={toggleDrawer(false)}
     >
+      {/* TODO: Drawerの幅が確定していないので確定しだい定数化する */}
       <Box
         sx={{ width: 500 }}
         onClick={toggleDrawer(false)}

--- a/components/ui-parts/FormDrawer.tsx
+++ b/components/ui-parts/FormDrawer.tsx
@@ -12,7 +12,6 @@ const userProfileSrcPath = '/no_image.png';
 const userProfileName = 'noname';
 
 const FormDrawer: FC<FormDrawerProps> = ({ planInfo, drawerOpen, setDrawerOpen }) => {
-
   const handleContentClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
   }

--- a/components/ui-parts/FormDrawer.tsx
+++ b/components/ui-parts/FormDrawer.tsx
@@ -1,9 +1,10 @@
-import React, { FC } from 'react'
+import React, { FC } from 'react';
+
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 
 import ImageWrapper from '@/components/ui-elements/ImageWrapper';
-import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import { FormDrawerProps } from '@/features/plans/types/plan';
 import { USER_PROFILE_HEIGHT_SM, USER_PROFILE_WIDTH_SM } from '@/common/constans/sizes';
 

--- a/components/ui-parts/FormDrawer.tsx
+++ b/components/ui-parts/FormDrawer.tsx
@@ -1,0 +1,88 @@
+import React, { FC } from 'react'
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+
+import ImageWrapper from '@/components/ui-elements/ImageWrapper';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
+import { FormDrawerProps } from '@/features/plans/types/plan';
+import { USER_PROFILE_HEIGHT_SM, USER_PROFILE_WIDTH_SM } from '@/common/constans/sizes';
+
+// TODO: ユーザーの紐付けは後ほど対応
+const userProfileSrcPath = '/no_image.png';
+const userProfileName = 'noname';
+
+const FormDrawer: FC<FormDrawerProps> = ({ planInfo, drawerOpen, setDrawerOpen }) => {
+
+  const handleContentClick = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+  }
+
+  const toggleDrawer = (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
+    if ( event.type === 'keydown' &&
+      (
+        (event as React.KeyboardEvent).key === 'Tab' ||
+        (event as React.KeyboardEvent).key === 'Shift'
+      )
+    ) { return; }
+
+    setDrawerOpen(open);
+  };
+
+  return (
+    <Drawer
+      anchor="right"
+      open={drawerOpen}
+      onClose={toggleDrawer(false)}
+    >
+      <Box
+        sx={{ width: 500 }}
+        onClick={toggleDrawer(false)}
+        onKeyDown={toggleDrawer(false)}
+      >
+        {/* TODO: レイアウト実装。フォームは後ほど対応 */}
+        <div onClick={handleContentClick}>
+          <div className='bg-gray-100 p-4'>
+            <button className='py-1 px-2 text-[12px] bg-white border rounded-md transition-all hover:bg-gray-100'>積み上げに登録</button>
+          </div>
+          <div className='py-4 px-8'>
+            <h1 className='text-2xl mb-8'>{planInfo.title}</h1>
+            <div className='flex items-center mb-4'>
+              <p className='text-sm text-gray-500 w-[20%]'>名前</p>
+              <p className='flex items-center text-sm'>
+                <ImageWrapper
+                  src={userProfileSrcPath}
+                  height={USER_PROFILE_HEIGHT_SM}
+                  width={USER_PROFILE_WIDTH_SM}
+                  alt={userProfileName}
+                  className='rounded-full mr-2'
+                />
+                <span>Yuya Minami</span>
+              </p>
+            </div>
+            <div className='flex items-center mb-4'>
+              <p className='text-sm text-gray-500 w-[20%]'>日時</p>
+              <p className='flex items-center text-sm'>
+                <span>{planInfo.start}</span>
+                <span className='mx-2'> - </span>
+                <span>{planInfo.end}</span>
+              </p>
+            </div>
+            <div className='flex items-center mb-10'>
+              <p className='text-sm text-gray-500 w-[20%]'>スキル</p>
+              <p className='flex items-center text-sm'>
+                <LocalOfferIcon sx={{ fontSize: 16, color: '#CCCCCC', mr: '4px' }} />
+                <span>{planInfo.skill}</span>
+              </p>
+            </div>
+            <div>
+              <p className='text-sm text-gray-500 mb-4'>説明</p>
+              <p className='text-sm'>{planInfo.description}</p>
+            </div>
+          </div>
+        </div>
+      </Box>
+    </Drawer>
+  )
+}
+
+export default FormDrawer

--- a/features/plans/constants/plan.ts
+++ b/features/plans/constants/plan.ts
@@ -1,0 +1,7 @@
+export const initialPlanData = {
+  title: '',
+  description: '',
+  skill: '',
+  start: new Date().toLocaleString(),
+  end: new Date().toLocaleString()
+};

--- a/features/plans/styles/style.css
+++ b/features/plans/styles/style.css
@@ -46,3 +46,14 @@
   background-color: #e4f5ff;
   transition: .2s all;
 }
+
+.MuiBackdrop-root {
+  background-color: transparent;
+}
+
+.MuiPaper-root {
+  height: calc(100vh - 60px);
+  top: auto;
+  bottom: 0;
+  z-index: 9999;
+}

--- a/features/plans/types/plan.ts
+++ b/features/plans/types/plan.ts
@@ -1,12 +1,20 @@
 export type SetEvents =  React.Dispatch<React.SetStateAction<EventsProps[]>>;
 
-export interface HolidayProps{
+export interface HolidayProps {
   localName: string,
   date: string,
 }
 
 export interface EventsProps {
   title: string,
+  description: string,
+  skill: string,
   start: string,
-  end: string
+  end: string,
+}
+
+export type FormDrawerProps = {
+  planInfo: EventsProps;
+  drawerOpen: boolean;
+  setDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/pages/plan/index.tsx
+++ b/pages/plan/index.tsx
@@ -42,8 +42,10 @@ const Index: NextPage = () => {
   }, []);
 
   const handleEventClick = (clickInfo: EventClickArg) => {
-    const startTime = clickInfo.event.start && clickInfo.event.start.toLocaleString() || new Date().toLocaleString();
-    const endTime = clickInfo.event.end && clickInfo.event.end.toLocaleString() || new Date().toLocaleString();
+    const event = clickInfo.event;
+    const today = new Date().toLocaleString();
+    const startTime = event.start && event.start.toLocaleString() || today;
+    const endTime = event.end && event.end.toLocaleString() || today;
 
     setDrawerOpen(true)
     setPlanInfo({

--- a/pages/plan/index.tsx
+++ b/pages/plan/index.tsx
@@ -1,17 +1,19 @@
 import { NextPage } from 'next'
 import React, { useEffect, useState } from 'react'
-import Layout from '@/components/layouts/Layout'
+
 import FullCalendar from '@fullcalendar/react'
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import listPlugin from '@fullcalendar/list';
 import interactionPlugin from '@fullcalendar/interaction'
 import jaLocale from '@fullcalendar/core/locales/ja';
+import { EventClickArg } from '@fullcalendar/core';
+
+import Layout from '@/components/layouts/Layout'
+import FormDrawer from '@/components/ui-parts/FormDrawer';
 import { EventsProps } from '@/features/plans/types/plan';
 import { getHoliday } from '@/features/plans/functions/holiday';
-import { EventClickArg } from '@fullcalendar/core';
 import { initialPlanData } from '@/features/plans/constants/plan';
-import FormDrawer from '@/components/ui-parts/FormDrawer';
 
 const Index: NextPage = () => {
   // TODO: 一旦仮データ挿入、予定作成のタイミングで改修

--- a/pages/plan/index.tsx
+++ b/pages/plan/index.tsx
@@ -9,17 +9,49 @@ import interactionPlugin from '@fullcalendar/interaction'
 import jaLocale from '@fullcalendar/core/locales/ja';
 import { EventsProps } from '@/features/plans/types/plan';
 import { getHoliday } from '@/features/plans/functions/holiday';
+import { EventClickArg } from '@fullcalendar/core';
+import { initialPlanData } from '@/features/plans/constants/plan';
+import FormDrawer from '@/components/ui-parts/FormDrawer';
 
 const Index: NextPage = () => {
   // TODO: 一旦仮データ挿入、予定作成のタイミングで改修
   const [events, setEvents] = useState<EventsProps[]>([
-    { title: '午前中のミーティング', start: '2024-03-11T09:00:00', end: '2024-03-11T12:00:00' },
-    { title: '午後の作業時間', start: '2024-03-11T13:00:00', end: '2024-03-11T17:00:00' }
+    {
+      title: '午前中のミーティング',
+      start: '2024-03-26T09:00',
+      end: '2024-03-26T12:00',
+      description: 'このミーティングではプロジェクトの進行状況を確認します。このミーティングではプロジェクトの進行状況を確認します。このミーティングではプロジェクトの進行状況を確認します。',
+      skill: 'プログラミング'
+    },
+    {
+      title: '午後の作業時間',
+      start: '2024-03-26T13:00',
+      end: '2024-03-26T17:00',
+      description: 'このミーティングではプロジェクトの進行状況を確認します。このミーティングではプロジェクトの進行状況を確認します。このミーティングではプロジェクトの進行状況を確認します。',
+      skill: '読書'
+    }
   ]);
+
+  const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
+  const [planInfo, setPlanInfo] = useState<EventsProps>(initialPlanData)
 
   useEffect(() => {
     getHoliday(setEvents);
   }, []);
+
+  const handleEventClick = (clickInfo: EventClickArg) => {
+    const startTime = clickInfo.event.start && clickInfo.event.start.toLocaleString() || new Date().toLocaleString();
+    const endTime = clickInfo.event.end && clickInfo.event.end.toLocaleString() || new Date().toLocaleString();
+
+    setDrawerOpen(true)
+    setPlanInfo({
+      title: clickInfo.event.title,
+      description: clickInfo.event.extendedProps.description,
+      skill: clickInfo.event.extendedProps.skill,
+      start: startTime,
+      end: endTime,
+    })
+  };
 
   return (
     <Layout>
@@ -45,11 +77,13 @@ const Index: NextPage = () => {
             right: 'timeGridDay,timeGridWeek,dayGridMonth listWeek',
           }}
           events={events}
+          eventClick={handleEventClick}
           eventBackgroundColor={'#FFFFFF'}
           eventBorderColor={'#acaba9'}
           eventTextColor={'#37362f'}
         />
       </div>
+      <FormDrawer drawerOpen={drawerOpen} planInfo={planInfo} setDrawerOpen={setDrawerOpen} />
     </Layout>
   )
 }


### PR DESCRIPTION
## Epic
[1日の計画表を感覚的に作成できる](https://github.com/users/ren0826nosuke/projects/1/views/1?pane=issue&itemId=52732130)

## PBI
[UI上で計画の詳細を表示できるようにする](https://github.com/users/ren0826nosuke/projects/1/views/1?pane=issue&itemId=57819824)

## 対象画面キャプチャ
https://github.com/mnmuu8/frontend_stack/assets/121008362/b0b909f7-9283-4c13-a92c-a61581930c32

## 実行するコマンド


## やったこと
- モーダルレイアウトの変更した
- 予定をクリックした時に詳細を表示できるようにした

## このPRでやらないこと


## 動作確認
- [x] 確認済み

## その他
